### PR TITLE
chore: add navigation

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -1,15 +1,65 @@
 import React from 'react';
+import SplitPane from 'react-split-pane';
 
 import { Editor } from './Editor/Editor';
+import { Navigation } from './Navigation';
 import { Template } from './Template';
+
+import { debounce } from '../helpers';
+import state from '../state';
 
 interface ContentProps {}
 
 export const Content: React.FunctionComponent<ContentProps> = () => {
+  const sidebarState = state.useSidebarState();
+
+  const navigationEnabled = sidebarState.panels.navigation.get();
+  const editorEnabled = sidebarState.panels.editor.get();
+  const templateEnabled = sidebarState.panels.template.get();
+
+  const navigationAndEditor = (
+    <SplitPane
+      minSize={220}
+      maxSize={360}
+      pane1Style={!navigationEnabled ? { width: '0px' } : { overflow: 'auto' }}
+      pane2Style={!editorEnabled ? { width: '0px' } : undefined}
+      primary={!editorEnabled ? 'second' : 'first'}
+      defaultSize={
+        parseInt(localStorage.getItem('splitPos:left') || '0', 10) || 220
+      }
+      onChange={debounce((size: string) => {
+        localStorage.setItem('splitPos:left', String(size));
+      }, 100)}
+    >
+      <Navigation />
+      <Editor />
+    </SplitPane>
+  );
+
   return (
     <div className="flex flex-1 flex-row relative">
-      <Editor />
-      <Template />
+      <div className="flex flex-1 flex-row relative">
+        <SplitPane
+          minSize={0}
+          pane1Style={
+            !navigationEnabled && !editorEnabled ? { width: '0px' } : undefined
+          }
+          pane2Style={
+            !templateEnabled ? { width: '0px' } : { overflow: 'auto' }
+          }
+          primary={!templateEnabled ? 'second' : 'first'}
+          defaultSize={
+            parseInt(localStorage.getItem('splitPos:center') || '0', 10) ||
+            '55%'
+          }
+          onChange={debounce((size: string) => {
+            localStorage.setItem('splitPos:center', String(size));
+          }, 100)}
+        >
+          {navigationAndEditor}
+          <Template />
+        </SplitPane>
+      </div>
     </div>
   );
 };

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -21,9 +21,9 @@ export const Content: React.FunctionComponent<ContentProps> = () => {
     <SplitPane
       minSize={220}
       maxSize={360}
-      pane1Style={!navigationEnabled ? { width: '0px' } : { overflow: 'auto' }}
-      pane2Style={!editorEnabled ? { width: '0px' } : undefined}
-      primary={!editorEnabled ? 'second' : 'first'}
+      pane1Style={navigationEnabled ? { overflow: 'auto' } : { width: '0px' }}
+      pane2Style={editorEnabled ? undefined : { width: '0px' }}
+      primary={editorEnabled ? 'first' : 'second'}
       defaultSize={
         parseInt(localStorage.getItem('splitPos:left') || '0', 10) || 220
       }
@@ -42,12 +42,12 @@ export const Content: React.FunctionComponent<ContentProps> = () => {
         <SplitPane
           minSize={0}
           pane1Style={
-            !navigationEnabled && !editorEnabled ? { width: '0px' } : undefined
+            navigationEnabled || editorEnabled ? undefined : { width: '0px' }
           }
           pane2Style={
-            !templateEnabled ? { width: '0px' } : { overflow: 'auto' }
+            templateEnabled ? { overflow: 'auto' } : { width: '0px' }
           }
-          primary={!templateEnabled ? 'second' : 'first'}
+          primary={templateEnabled ? 'first' : 'second'}
           defaultSize={
             parseInt(localStorage.getItem('splitPos:center') || '0', 10) ||
             '55%'

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,357 @@
+import React, { useEffect, useState } from 'react';
+
+import { AsyncAPIDocument } from '@asyncapi/parser';
+
+import state from '../state';
+import { NavigationService } from '../services';
+
+interface NavigationProps {}
+
+interface NavigationSectionProps {
+  spec: AsyncAPIDocument;
+  rawSpec: string;
+  language: string;
+  hash: string;
+}
+
+export const Navigation: React.FunctionComponent<NavigationProps> = () => {
+  const [hash, setHash] = useState(window.location.hash);
+
+  const editorState = state.useEditorState();
+  const parserState = state.useParserState();
+
+  const rawSpec = editorState.editorValue.get();
+  const language = editorState.language.get();
+  const spec = parserState.parsedSpec.get();
+
+  useEffect(() => {
+    // remove `#` char
+    setHash(window.location.hash.substring(1));
+    const fn = () => {
+      // remove `#` char
+      setHash(window.location.hash.substring(1));
+    };
+    window.addEventListener('hashchange', fn);
+    return () => {
+      window.removeEventListener('hashchange', fn);
+    };
+  }, []);
+
+  if (editorState.editorLoaded.get() === false) {
+    return (
+      <div className="flex overflow-hidden bg-gray-800 h-full justify-center items-center text-center text-white text-md px-6">
+        Loading...
+      </div>
+    );
+  }
+
+  if (!rawSpec || !spec || typeof spec === 'string') {
+    return (
+      <div className="flex overflow-hidden bg-gray-800 h-full justify-center items-center text-center text-white text-md px-6">
+        Empty or invalid document. Please fix errors/define AsyncAPI document.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-none flex-col overflow-y-auto overflow-x-hidden bg-gray-800 h-full">
+      <ul>
+        <li className="mb-4">
+          <div
+            className={`p-2 pl-3 text-white cursor-pointer hover:bg-gray-900 ${
+              hash === 'introduction' ? 'bg-gray-900' : ''
+            }`}
+            onClick={() =>
+              NavigationService.scrollTo(
+                '/info',
+                rawSpec,
+                'introduction',
+                language,
+              )
+            }
+          >
+            Introduction
+          </div>
+        </li>
+        {spec.hasServers() && (
+          <li className="mb-4">
+            <ServersNavigation
+              spec={spec}
+              rawSpec={rawSpec}
+              language={language}
+              hash={hash}
+            />
+          </li>
+        )}
+        <li className="mb-4">
+          <OperationsNavigation
+            spec={spec}
+            rawSpec={rawSpec}
+            language={language}
+            hash={hash}
+          />
+        </li>
+        {spec.hasComponents() && spec.components().hasMessages() && (
+          <li className="mb-4">
+            <MessagesNavigation
+              spec={spec}
+              rawSpec={rawSpec}
+              language={language}
+              hash={hash}
+            />
+          </li>
+        )}
+        {spec.hasComponents() && spec.components().hasSchemas() && (
+          <li className="mb-4">
+            <SchemasNavigation
+              spec={spec}
+              rawSpec={rawSpec}
+              language={language}
+              hash={hash}
+            />
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+const ServersNavigation: React.FunctionComponent<NavigationSectionProps> = ({
+  spec,
+  rawSpec,
+  language,
+  hash,
+}) => {
+  return (
+    <>
+      <div
+        className={`p-2 pl-3 text-white cursor-pointer hover:bg-gray-900 ${
+          hash === 'servers' ? 'bg-gray-900' : ''
+        }`}
+        onClick={() =>
+          NavigationService.scrollTo('/servers', rawSpec, 'servers', language)
+        }
+      >
+        Servers
+      </div>
+      <ul>
+        {Object.entries(spec.servers() || {}).map(([serverName, server]) => (
+          <li
+            key={serverName}
+            className={`p-2 pl-3 text-white cursor-pointer text-xs border-t border-gray-700 hover:bg-gray-900 ${
+              hash === `server-${serverName}` ? 'bg-gray-900' : ''
+            }`}
+            onClick={() =>
+              NavigationService.scrollTo(
+                `/servers/${serverName.replace(/\//g, '~1')}`,
+                rawSpec,
+                `server-${serverName}`,
+                language,
+              )
+            }
+          >
+            <div className="flex flex-row">
+              <div className="flex-none">
+                <span className="mr-3 text-xs uppercase text-pink-500 font-bold">
+                  {server.protocolVersion()
+                    ? `${server.protocol()} ${server.protocolVersion()}`
+                    : server.protocol()}
+                </span>
+              </div>
+              <span className="truncate">{serverName}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+};
+
+const OperationsNavigation: React.FunctionComponent<NavigationSectionProps> = ({
+  spec,
+  rawSpec,
+  language,
+  hash,
+}) => {
+  const operations = Object.entries(spec.channels() || {}).map(
+    ([channelName, channel]) => {
+      const channels: React.ReactNodeArray = [];
+
+      if (channel.hasPublish()) {
+        channels.push(
+          <li
+            key={`${channelName}-publish`}
+            className={`p-2 pl-3 text-white cursor-pointer text-xs border-t border-gray-700 hover:bg-gray-900 ${
+              hash === `operation-publish-${channelName}` ? 'bg-gray-900' : ''
+            }`}
+            onClick={() =>
+              NavigationService.scrollTo(
+                `/channels/${channelName.replace(/\//g, '~1')}`,
+                rawSpec,
+                `operation-publish-${channelName}`,
+                language,
+              )
+            }
+          >
+            <div className="flex flex-row">
+              <div className="flex-none">
+                <span className="mr-3 text-xs uppercase text-blue-500 font-bold">
+                  Pub
+                </span>
+              </div>
+              <span className="truncate">{channelName}</span>
+            </div>
+          </li>,
+        );
+      }
+      if (channel.hasSubscribe()) {
+        channels.push(
+          <li
+            key={`${channelName}-subscribe`}
+            className={`p-2 pl-3 text-white cursor-pointer text-xs border-t border-gray-700 hover:bg-gray-900 ${
+              hash === `operation-subscribe-${channelName}` ? 'bg-gray-900' : ''
+            }`}
+            onClick={() =>
+              NavigationService.scrollTo(
+                `/channels/${channelName.replace(/\//g, '~1')}`,
+                rawSpec,
+                `operation-subscribe-${channelName}`,
+                language,
+              )
+            }
+          >
+            <div className="flex flex-row">
+              <div className="flex-none">
+                <span className="mr-3 text-xs uppercase text-green-600 font-bold">
+                  Sub
+                </span>
+              </div>
+              <span className="truncate">{channelName}</span>
+            </div>
+          </li>,
+        );
+      }
+
+      return channels;
+    },
+  );
+
+  return (
+    <>
+      <div
+        className={`p-2 pl-3 text-white cursor-pointer hover:bg-gray-900 ${
+          hash === 'operations' ? 'bg-gray-900' : ''
+        }`}
+        onClick={() =>
+          NavigationService.scrollTo(
+            '/channels',
+            rawSpec,
+            'operations',
+            language,
+          )
+        }
+      >
+        Operations
+      </div>
+      <ul>{operations}</ul>
+    </>
+  );
+};
+
+const MessagesNavigation: React.FunctionComponent<NavigationSectionProps> = ({
+  spec,
+  rawSpec,
+  language,
+  hash,
+}) => {
+  const messages = Object.keys(spec.components().messages() || {}).map(
+    messageName => (
+      <li
+        key={messageName}
+        className={`p-2 pl-6 text-white cursor-pointer text-xs border-t border-gray-700 hover:bg-gray-900 truncate ${
+          hash === `message-${messageName}` ? 'bg-gray-900' : ''
+        }`}
+        onClick={() =>
+          NavigationService.scrollTo(
+            `/components/messages/${messageName.replace(/\//g, '~1')}`,
+            rawSpec,
+            `message-${messageName}`,
+            language,
+          )
+        }
+      >
+        {messageName}
+      </li>
+    ),
+  );
+
+  return (
+    <>
+      <div
+        className={`p-2 pl-3 text-white cursor-pointer hover:bg-gray-900 ${
+          hash === 'messages' ? 'bg-gray-900' : ''
+        }`}
+        onClick={() =>
+          NavigationService.scrollTo(
+            '/components/messages',
+            rawSpec,
+            'messages',
+            language,
+          )
+        }
+      >
+        Messages
+      </div>
+      <ul>{messages}</ul>
+    </>
+  );
+};
+
+const SchemasNavigation: React.FunctionComponent<NavigationSectionProps> = ({
+  spec,
+  rawSpec,
+  language,
+  hash,
+}) => {
+  const schemas = Object.keys(spec.components().schemas() || {}).map(
+    schemaName => (
+      <li
+        key={schemaName}
+        className={`p-2 pl-6 text-white cursor-pointer text-xs border-t border-gray-700 hover:bg-gray-900 truncate ${
+          hash === `schema-${schemaName}` ? 'bg-gray-900' : ''
+        }`}
+        onClick={() =>
+          NavigationService.scrollTo(
+            `/components/schemas/${schemaName.replace(/\//g, '~1')}`,
+            rawSpec,
+            `schema-${schemaName}`,
+            language,
+          )
+        }
+      >
+        {schemaName}
+      </li>
+    ),
+  );
+
+  return (
+    <>
+      <div
+        className={`p-2 pl-3 text-white cursor-pointer hover:bg-gray-900 ${
+          hash === 'schemas' ? 'bg-gray-900' : ''
+        }`}
+        onClick={() =>
+          NavigationService.scrollTo(
+            '/components/schemas',
+            rawSpec,
+            'schemas',
+            language,
+          )
+        }
+      >
+        Schemas
+      </div>
+      <ul>{schemas}</ul>
+    </>
+  );
+};

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -26,11 +26,11 @@ export const Navigation: React.FunctionComponent<NavigationProps> = () => {
 
   useEffect(() => {
     // remove `#` char
-    setHash(window.location.hash.substring(1));
     const fn = () => {
       // remove `#` char
       setHash(window.location.hash.substring(1));
     };
+    fn();
     window.addEventListener('hashchange', fn);
     return () => {
       window.removeEventListener('hashchange', fn);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { StateMethods } from '@hookstate/core';
+import { VscListSelection, VscCode, VscOpenPreview } from 'react-icons/vsc';
+
+import state from '../state';
+
+interface NavItem {
+  name: string;
+  state: StateMethods<boolean>;
+  icon: React.ReactNode;
+}
+
+interface SidebarProps {}
+
+export const Sidebar: React.FunctionComponent<SidebarProps> = () => {
+  const sidebarState = state.useSidebarState();
+
+  if (sidebarState.show.get() === false) {
+    return null;
+  }
+
+  const navigation: NavItem[] = [
+    // navigation
+    {
+      name: 'navigation',
+      state: sidebarState.panels.navigation,
+      icon: <VscListSelection className="w-5 h-5" />,
+    },
+    // editor
+    {
+      name: 'editor',
+      state: sidebarState.panels.editor,
+      icon: <VscCode className="w-5 h-5" />,
+    },
+    // template
+    {
+      name: 'template',
+      state: sidebarState.panels.template,
+      icon: <VscOpenPreview className="w-5 h-5" />,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col flex-none bg-gray-800 shadow-lg border-r border-gray-700 justify-between">
+      <div className="flex flex-col">
+        {navigation.map(item => (
+          <button
+            key={item.name}
+            onClick={() => item.state.set(v => !v)}
+            className={`flex text-sm border-l-2  ${
+              item.state.get()
+                ? 'text-white hover:text-gray-500 border-white'
+                : 'text-gray-500 hover:text-white border-gray-800'
+            } focus:outline-none border-box p-4`}
+            type="button"
+          >
+            {item.icon}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,5 @@
 export * from './Editor';
 export * from './Content';
+export * from './Navigation';
+export * from './Sidebar';
 export * from './Toolbar';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,8 @@ import ReactDOM from 'react-dom';
 import App from './App';
 
 import '@asyncapi/react-component/styles/default.min.css';
-import "tailwindcss/dist/tailwind.min.css"
+import "tailwindcss/dist/tailwind.min.css";
+import "./main.css";
 
 window.MonacoEnvironment = window.MonacoEnvironment || {
   getWorkerUrl: function(_: string, label: string) {

--- a/src/main.css
+++ b/src/main.css
@@ -1,0 +1,50 @@
+.Resizer {
+  background: #374251;
+  z-index: 1;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  -moz-background-clip: padding;
+  -webkit-background-clip: padding;
+  background-clip: padding-box;
+}
+
+.Resizer:hover {
+  -webkit-transition: all 2s ease;
+  transition: all 2s ease;
+}
+
+.Resizer.horizontal {
+  height: 11px;
+  margin: -5px 0;
+  border-top: 5px solid rgba(255, 255, 255, 0);
+  border-bottom: 5px solid rgba(255, 255, 255, 0);
+  cursor: row-resize;
+  width: 100%;
+}
+
+.Resizer.horizontal:hover {
+  border-top: 5px solid rgba(0, 0, 0, 0.5);
+  border-bottom: 5px solid rgba(0, 0, 0, 0.5);
+}
+
+.Resizer.vertical {
+  width: 11px;
+  margin: 0 -5px;
+  border-left: 5px solid rgba(255, 255, 255, 0);
+  border-right: 5px solid rgba(255, 255, 255, 0);
+  cursor: col-resize;
+}
+
+.Resizer.vertical:hover {
+  border-left: 5px solid rgba(0, 0, 0, 0.5);
+  border-right: 5px solid rgba(0, 0, 0, 0.5);
+}
+
+.Resizer.disabled {
+  cursor: not-allowed;
+}
+
+.Resizer.disabled:hover {
+  border-color: transparent;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,5 @@
 export * from './editor.service';
+export * from './format.service';
 export * from './monaco.service';
+export * from './navigation.service';
 export * from './specification.service';

--- a/src/services/navigation.service.ts
+++ b/src/services/navigation.service.ts
@@ -1,0 +1,63 @@
+// @ts-ignore
+import { getLocationOf } from '@asyncapi/parser/lib/utils';
+
+interface LocationOf {
+  jsonPointer: string;
+  startLine: number;
+  startColumn: number;
+  startOffset: number;
+  endLine?: number;
+  endColumn?: number;
+  endOffset?: number;
+}
+
+export class NavigationService {
+  static scrollTo(
+    jsonPointer: any,
+    spec: any,
+    hash: string,
+    language: string = 'yaml',
+  ) {
+    try {
+      const location: LocationOf = getLocationOf(jsonPointer, spec, language);
+      if (!location || typeof location.startLine !== 'number') {
+        return;
+      }
+
+      this.scrollToHash(hash);
+      this.scrollToEditorLine(location.startLine);
+      this.emitHashChangeEvent(hash);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  static scrollToHash(hash?: string) {
+    hash = hash || window.location.hash.substring(1);
+    try {
+      const escapedHash = CSS.escape(hash);
+      const items = document.querySelectorAll(
+        escapedHash.startsWith('#') ? escapedHash : `#${escapedHash}`,
+      );
+      if (items.length) {
+        const element = items[0];
+        typeof element.scrollIntoView === 'function' &&
+          element.scrollIntoView({ behavior: 'smooth' });
+      }
+    } catch (e) {}
+  }
+
+  static scrollToEditorLine(startLine: number) {
+    try {
+      const editor = window.Editor;
+      editor && editor.revealLineInCenter(startLine);
+      editor && editor.setPosition({ column: 1, lineNumber: startLine });
+    } catch (err) {}
+  }
+
+  private static emitHashChangeEvent(hash: string) {
+    hash = hash.startsWith('#') ? hash : `#${hash}`;
+    window.history.pushState({}, '', hash);
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+  }
+}

--- a/src/studio.tsx
+++ b/src/studio.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Toaster } from 'react-hot-toast';
 
-import { Content, Toolbar } from './components';
+import { Content, Sidebar, Toolbar } from './components';
 
 export interface AsyncAPIStudioProps {}
 
@@ -10,6 +10,7 @@ const AsyncAPIStudio: React.FunctionComponent<AsyncAPIStudioProps> = () => {
     <div className="flex flex-col h-full w-full h-screen">
       <Toolbar />
       <div className="flex flex-row flex-1 overflow-hidden">
+        <Sidebar />
         <Content />
       </div>
       <Toaster position="bottom-center" reverseOrder={false} />


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- add `Navigation` component next to editor and template.
- add `NavigationService` with `scrollTo` functions - based on `hashchange` event.
- add `Sidebar` component with the ability to hide the given block - navigation, editor or template.
- add "stretching" functionality - navigation, editor, template can be stretched to the given horizontal size.
- update relevant component like `Content` and main file.
- add `main.css` file with styles for "stretching" functionality.

![image](https://user-images.githubusercontent.com/20404945/135420493-a757a0f6-3bc6-4edb-8d87-f4980c6b4f31.png)

**Related issue(s)**
See also https://github.com/asyncapi/studio/issues/80