### PR TITLE
fix: remove homepage from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "One place that allows you to develop an AsyncAPI document, validate it, convert it to the latest version, preview the documentation and visualize the events flow.",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/asyncapi/studio",
   "bugs": {
     "url": "https://github.com/asyncapi/studio/issues"
   },


### PR DESCRIPTION
I'm removing `homepage` from package.json because it's causing the client HTML to load resources from `/asyncapi/studio` path, and is obviously not there but in `/`.

After that, Studio will be online at studio.asyncapi.com 🚀 