### PR TITLE
fix: update the default version of the asyncapi it loads (#143)

### DIFF
--- a/src/state/editor.ts
+++ b/src/state/editor.ts
@@ -1,82 +1,169 @@
 import { createState, useState } from '@hookstate/core';
 
 const schema =
-  localStorage.getItem('document') ||
-  `asyncapi: 2.2.0
-id: 'urn:rpc:example:client'
-defaultContentType: application/json
-
+  localStorage.getItem('document') || `asyncapi: '2.2.0'
 info:
-  title: RPC Client Example
-  description: This example demonstrates how to define an RPC client.
-  version: 1.0.0
+  title: Streetlights Kafka API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+    ### Check out its awesome features:
+
+    * Turn a specific streetlight on/off 🌃
+    * Dim a specific streetlight 😎
+    * Receive real-time information about environmental lighting conditions 📈
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
 
 servers:
-  production:
-    url: rabbitmq.example.org
-    protocol: amqp
-    
-channels:
-  '{queue}':
-    parameters:
-      queue:
-        schema:
-          type: string
-          pattern: ^amq\\.gen\\-.+$
-    bindings:
-      amqp:
-        is: queue
-        queue:
-          exclusive: true
-    subscribe:
-      operationId: receiveSumResult
-      bindings:
-        amqp:
-          ack: false
-      message:
-        correlationId:
-          location: $message.header#/correlation_id
-        payload:
-          $ref: '#/components/schemas/test'
+  test:
+    url: test.mykafkacluster.org:8092
+    protocol: kafka-secure
+    description: Test broker
+    security:
+      - saslScram: []
 
-  rpc_queue:
-    bindings:
-      amqp:
-        is: queue
-        queue:
-          durable: false
+defaultContentType: application/json
+
+channels:
+  smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
     publish:
-      operationId: requestSum
-      bindings:
-        amqp:
-          ack: true
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
       message:
-        bindings:
-          amqp:
-            replyTo:
-              type: string
-        correlationId:
-          location: $message.header#/correlation_id
-        payload:
-          type: object
-          properties:
-            numbers:
-              type: array
-              items:
-                type: number
-              examples:
-                - - 4
-                  - 3
-                  
+        $ref: '#/components/messages/lightMeasured'
+
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.on:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOn
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.off:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOff
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting.streetlights.1.0.action.{streetlightId}.dim:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: dimLight
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/dimLight'
+
 components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+    turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
+      summary: Command a particular streetlight to turn the lights on or off.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/turnOnOffPayload"
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+
   schemas:
-    test:
+    lightMeasuredPayload:
       type: object
       properties:
-        result:
-          type: number
-          examples:
-            - 7
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    turnOnOffPayload:
+      type: object
+      properties:
+        command:
+          type: string
+          enum:
+            - on
+            - off
+          description: Whether to turn on or off the light.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+
+  securitySchemes:
+    saslScram:
+      type: scramSha256
+      description: Provide your username and password for SASL/SCRAM authentication
+
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId: my-app-id
 `;
 
 export type EditorStateDocumentFrom = 'localStorage' | `URL: ${string}` | 'Base64';


### PR DESCRIPTION
**Description**

Fix for #143

This uses `2.2.0` as the default of the file vs `2.0.0` and no longer shows the popup when using the studio.

The file seems to render OK, I used the tool to upgrade the `2.0.0` version to `2.2.0` and it just changed the `examples` property (can you can see in the changes). I guess this is correct?

I guess in the future we might want a more "elegant" way to do this, when we do new releases going forward we will always have to do this, but I think it's OK for now.
