### PR TITLE
chore: redirect editor.asyncapi.org to studio.asyncapi.com

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,4 @@
+# Redirect editor.asyncapi.org to Studio
+
+http://editor.asyncapi.org/* https://studio.asyncapi.com 301!
+https://editor.asyncapi.org/* https://studio.asyncapi.com 301!


### PR DESCRIPTION
### Description

We're shutting down [editor.asyncapi.org](http://editor.asyncapi.org) but we don't want to show a 404 to users but instead give them the alternative to use Studio. For that purpose, I want to redirect to Studio here.

### Notes

If you navigate to [editor.asyncapi.org](http://editor.asyncapi.org), you'll notice that the redirect is already in place. This is because I've edited the code in its machine to do the redirect.

##### So why redirect here then, Fran? Is it too Monday for you?

Yes, it's too Monday for me 😄 However, this redirect is happening because I'm paying for a DigitalOcean droplet (machine) to handle it. I want to stop paying for this stupid redirect so I'll change DNS in Netlify to point to Studio. It's not possible to do redirects with DNS and therefore I want the code here to be ready for when the new DNS is in place.

Bye bye AsyncAPI 1.0.0 Editor, you served us well 👋 😢 😄 