### PR TITLE
fix: update react-component to next-27 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@asyncapi/converter": "^0.6.0",
         "@asyncapi/parser": "^1.12.0",
-        "@asyncapi/react-component": "^1.0.0-next.26",
+        "@asyncapi/react-component": "^1.0.0-next.27",
         "@asyncapi/specs": "^2.12.0",
         "@headlessui/react": "1.4.1",
         "@hookstate/core": "^3.0.12",
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@asyncapi/react-component": {
-      "version": "1.0.0-next.26",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.26.tgz",
-      "integrity": "sha512-30UnzdbS7EVcdxIHru8O04mxqGPmTA0o2HtzykV9+Y0Ye+k9gqto8SK1my+qqQUs+7EwwyzA1dFaTmf2CHrJIg==",
+      "version": "1.0.0-next.27",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.27.tgz",
+      "integrity": "sha512-kePEkutyk0qRLSn8yukAvq28KZ63P8ZS/oxaw7xB+JPdWSWpf269uup3YJq/f9KVZY/0/v8Nel2dRjZ2y7QTxQ==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^0.3.0",
         "@asyncapi/openapi-schema-parser": "^2.0.0",
@@ -31318,9 +31318,9 @@
       }
     },
     "@asyncapi/react-component": {
-      "version": "1.0.0-next.26",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.26.tgz",
-      "integrity": "sha512-30UnzdbS7EVcdxIHru8O04mxqGPmTA0o2HtzykV9+Y0Ye+k9gqto8SK1my+qqQUs+7EwwyzA1dFaTmf2CHrJIg==",
+      "version": "1.0.0-next.27",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.27.tgz",
+      "integrity": "sha512-kePEkutyk0qRLSn8yukAvq28KZ63P8ZS/oxaw7xB+JPdWSWpf269uup3YJq/f9KVZY/0/v8Nel2dRjZ2y7QTxQ==",
       "requires": {
         "@asyncapi/avro-schema-parser": "^0.3.0",
         "@asyncapi/openapi-schema-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@asyncapi/converter": "^0.6.0",
     "@asyncapi/parser": "^1.12.0",
-    "@asyncapi/react-component": "^1.0.0-next.26",
+    "@asyncapi/react-component": "^1.0.0-next.27",
     "@asyncapi/specs": "^2.12.0",
     "@headlessui/react": "1.4.1",
     "@hookstate/core": "^3.0.12",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Auto bumping script doesn't work -> https://github.com/asyncapi/asyncapi-react/runs/4700884362?check_suite_focus=true so I bump that dep manually.

**Related issue(s)**
Resolves https://github.com/asyncapi/studio/issues/221