### PR TITLE
fix: add support for avro and openapi formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.5.5",
       "license": "Apache-2.0",
       "dependencies": {
+        "@asyncapi/avro-schema-parser": "^1.0.1",
         "@asyncapi/converter": "^0.6.1",
+        "@asyncapi/openapi-schema-parser": "^2.0.1",
         "@asyncapi/parser": "^1.12.0",
         "@asyncapi/react-component": "^1.0.0-next.31",
         "@asyncapi/specs": "^2.12.0",
@@ -72,9 +74,12 @@
       }
     },
     "node_modules/@asyncapi/avro-schema-parser": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.3.0.tgz",
-      "integrity": "sha512-gWAqS2CKxbChdX8hZY+5EYQl6atP8FTSBvoG5mGGQ89XUoNdlLX14lsvbgvBnDj5sSwqfs+b5Mh5PUZMR/8maA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-1.0.1.tgz",
+      "integrity": "sha512-j3JWLDkzWARlo2v/olOAgJ1aB9HNsvUUUHPKkx54ZNHUUbyVcDpQhBNSdvm8OBNKVa53QxLoDK7g59jhgUJZ9g==",
+      "dependencies": {
+        "avsc": "^5.7.3"
+      }
     },
     "node_modules/@asyncapi/converter": {
       "version": "0.6.1",
@@ -159,6 +164,11 @@
         "openapi-sampler": "^1.1.0",
         "use-resize-observer": "^7.0.0"
       }
+    },
+    "node_modules/@asyncapi/react-component/node_modules/@asyncapi/avro-schema-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.3.0.tgz",
+      "integrity": "sha512-gWAqS2CKxbChdX8hZY+5EYQl6atP8FTSBvoG5mGGQ89XUoNdlLX14lsvbgvBnDj5sSwqfs+b5Mh5PUZMR/8maA=="
     },
     "node_modules/@asyncapi/react-component/node_modules/marked": {
       "version": "4.0.10",
@@ -6271,6 +6281,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/avsc": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
+      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A==",
+      "engines": {
+        "node": ">=0.11"
       }
     },
     "node_modules/axe-core": {
@@ -32992,9 +33010,12 @@
       }
     },
     "@asyncapi/avro-schema-parser": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.3.0.tgz",
-      "integrity": "sha512-gWAqS2CKxbChdX8hZY+5EYQl6atP8FTSBvoG5mGGQ89XUoNdlLX14lsvbgvBnDj5sSwqfs+b5Mh5PUZMR/8maA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-1.0.1.tgz",
+      "integrity": "sha512-j3JWLDkzWARlo2v/olOAgJ1aB9HNsvUUUHPKkx54ZNHUUbyVcDpQhBNSdvm8OBNKVa53QxLoDK7g59jhgUJZ9g==",
+      "requires": {
+        "avsc": "^5.7.3"
+      }
     },
     "@asyncapi/converter": {
       "version": "0.6.1",
@@ -33072,6 +33093,11 @@
         "use-resize-observer": "^7.0.0"
       },
       "dependencies": {
+        "@asyncapi/avro-schema-parser": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-0.3.0.tgz",
+          "integrity": "sha512-gWAqS2CKxbChdX8hZY+5EYQl6atP8FTSBvoG5mGGQ89XUoNdlLX14lsvbgvBnDj5sSwqfs+b5Mh5PUZMR/8maA=="
+        },
         "marked": {
           "version": "4.0.10",
           "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
@@ -37671,6 +37697,11 @@
           }
         }
       }
+    },
+    "avsc": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.7.3.tgz",
+      "integrity": "sha512-uUbetCWczQHbsKyX1C99XpQHBM8SWfovvaZhPIj23/1uV7SQf0WeRZbiLpw0JZm+LHTChfNgrLfDJOVoU2kU+A=="
     },
     "axe-core": {
       "version": "4.3.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "./LICENSE"
   ],
   "dependencies": {
+    "@asyncapi/avro-schema-parser": "^1.0.1",
     "@asyncapi/converter": "^0.6.1",
+    "@asyncapi/openapi-schema-parser": "^2.0.1",
     "@asyncapi/parser": "^1.12.0",
     "@asyncapi/react-component": "^1.0.0-next.31",
     "@asyncapi/specs": "^2.12.0",

--- a/src/services/specification.service.ts
+++ b/src/services/specification.service.ts
@@ -1,6 +1,10 @@
 // @ts-ignore
 import { convert } from '@asyncapi/converter';
-import { parse, AsyncAPIDocument } from '@asyncapi/parser';
+import { parse, registerSchemaParser, AsyncAPIDocument } from '@asyncapi/parser';
+// @ts-ignore
+import openapiSchemaParser from '@asyncapi/openapi-schema-parser';
+// @ts-ignore
+import avroSchemaParser from '@asyncapi/avro-schema-parser';
 // @ts-ignore
 import specs from '@asyncapi/specs';
 
@@ -9,6 +13,9 @@ import { FormatService } from './format.service';
 import { MonacoService } from './monaco.service';
 
 import state from '../state';
+
+registerSchemaParser(openapiSchemaParser);
+registerSchemaParser(avroSchemaParser);
 
 export class SpecificationService {
   static getParsedSpec() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Add support for avro and openapi formats.

Why now? Because it is the first time when someone used `avro` schema in the Studio and got an error.... - #237  

The issue mentions that locally it works, but on https://studio.asyncapi.com it does not. This is because of how webpack works in production mode and in development mode. In development mode webpack "sees" all the packages that we use in all parts of the studio and for example `react-component` underneath "adds" support for avro and openapi. Due to the fact that Studio uses a smaller version of react-component without parser (parser is used in studio, so it doesn't need it), after building the application, where webpack "removes" any unused code, support for `avro` and `openapi` is forgotten, so we have to add support for `avro` and `openapi` again.

I don't want to release it as `feat:` because it's a bug, we should support it from beginning but we forgot to check that.

**Related issue(s)**
Fixes #237