### PR TITLE
fix: gitter spelling

### DIFF
--- a/src/examples/index.tsx
+++ b/src/examples/index.tsx
@@ -59,7 +59,7 @@ export default [
     type: templateTypes.realExample
   },
   {
-    title: 'Glitter Streaming API',
+    title: 'Gitter Streaming API',
     description: () => <>Gitter Streaming API from https://stream.gitter.im. Using HTTP protocol.</>,
     template: gitterStreaming,
     type: templateTypes.realExample


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- Fixed Gitter spelling typo in the `src/examples/index.tsx`

**Before**
![ss1](https://user-images.githubusercontent.com/22374829/150631339-95e44f54-814a-45d9-b013-76d43533d82c.png)

**After**
![ss2](https://user-images.githubusercontent.com/22374829/150631548-eaebf477-6109-4380-bc4c-d00ab778f8e5.png)

