### PR TITLE
fix: failing tests for newer versions of the converter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,13 @@
     "": {
       "name": "@asyncapi/studio",
       "version": "0.9.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^1.0.1",
-        "@asyncapi/converter": "^0.7.0",
+        "@asyncapi/converter": "^0.9.0",
         "@asyncapi/openapi-schema-parser": "^2.0.1",
         "@asyncapi/parser": "^1.14.1",
-        "@asyncapi/react-component": "^1.0.0-next.33",
+        "@asyncapi/react-component": "^1.0.0-next.34",
         "@asyncapi/specs": "^2.13.0",
         "@headlessui/react": "1.4.1",
         "@hookstate/core": "^3.0.12",
@@ -129,9 +128,9 @@
       }
     },
     "node_modules/@asyncapi/converter": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/converter/-/converter-0.7.0.tgz",
-      "integrity": "sha512-ZL3q/4yksxMoMjQ7WCz2KvSVqhkGlmmsUGBDfzEve38hBtC+7TsSWmyvbfOiQ/uLWPZwvnpfo1Vn5pDuk6qwLQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/converter/-/converter-0.9.0.tgz",
+      "integrity": "sha512-fAKrEwFjdMfoO1vwmifr/pe2Trna9QGSVj8GKY+6Nd2X6hs1OLQ+/OXvqhVnecL5ZcPy7t2pjDz3tcpMwV9Cdg==",
       "dependencies": {
         "commander": "^8.3.0",
         "js-yaml": "^3.14.1",
@@ -591,9 +590,9 @@
       }
     },
     "node_modules/@asyncapi/react-component": {
-      "version": "1.0.0-next.33",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.33.tgz",
-      "integrity": "sha512-3uUvOOimgqtqowGb+h73PvGKEgCMykEVxMQWHye/NH/+yDivelj6gX9mprGZQL3pWG2CVsUyPUd0vUuCrXOzcg==",
+      "version": "1.0.0-next.34",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.34.tgz",
+      "integrity": "sha512-4ZkF3vsKjaAaZ2qIPLfkmw73vCrop+qF2krPtAFSmk4wy8B+uMRK9bsObrf+QUSj4gSIQHezznMIZKAU91JTQw==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^0.3.0",
         "@asyncapi/openapi-schema-parser": "^2.0.0",
@@ -33401,9 +33400,9 @@
       }
     },
     "@asyncapi/converter": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/converter/-/converter-0.7.0.tgz",
-      "integrity": "sha512-ZL3q/4yksxMoMjQ7WCz2KvSVqhkGlmmsUGBDfzEve38hBtC+7TsSWmyvbfOiQ/uLWPZwvnpfo1Vn5pDuk6qwLQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/converter/-/converter-0.9.0.tgz",
+      "integrity": "sha512-fAKrEwFjdMfoO1vwmifr/pe2Trna9QGSVj8GKY+6Nd2X6hs1OLQ+/OXvqhVnecL5ZcPy7t2pjDz3tcpMwV9Cdg==",
       "requires": {
         "commander": "^8.3.0",
         "js-yaml": "^3.14.1",
@@ -33804,9 +33803,9 @@
       }
     },
     "@asyncapi/react-component": {
-      "version": "1.0.0-next.33",
-      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.33.tgz",
-      "integrity": "sha512-3uUvOOimgqtqowGb+h73PvGKEgCMykEVxMQWHye/NH/+yDivelj6gX9mprGZQL3pWG2CVsUyPUd0vUuCrXOzcg==",
+      "version": "1.0.0-next.34",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.34.tgz",
+      "integrity": "sha512-4ZkF3vsKjaAaZ2qIPLfkmw73vCrop+qF2krPtAFSmk4wy8B+uMRK9bsObrf+QUSj4gSIQHezznMIZKAU91JTQw==",
       "requires": {
         "@asyncapi/avro-schema-parser": "^0.3.0",
         "@asyncapi/openapi-schema-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
   ],
   "dependencies": {
     "@asyncapi/avro-schema-parser": "^1.0.1",
-    "@asyncapi/converter": "^0.7.0",
+    "@asyncapi/converter": "^0.9.0",
     "@asyncapi/openapi-schema-parser": "^2.0.1",
     "@asyncapi/parser": "^1.14.1",
-    "@asyncapi/react-component": "^1.0.0-next.33",
+    "@asyncapi/react-component": "^1.0.0-next.34",
     "@asyncapi/specs": "^2.13.0",
     "@headlessui/react": "1.4.1",
     "@hookstate/core": "^3.0.12",
@@ -50,7 +50,7 @@
   },
   "scripts": {
     "start": "cross-env DISABLE_ESLINT_PLUGIN=true craco start",
-    "build": "cross-env DISABLE_ESLINT_PLUGIN=true craco build",
+    "build": "npm run generate:template-parameters && cross-env DISABLE_ESLINT_PLUGIN=true craco build",
     "test": "npm run test:unit",
     "test:unit": "cross-env DISABLE_ESLINT_PLUGIN=true craco test --detectOpenHandles",
     "eject": "react-scripts eject",
@@ -62,7 +62,6 @@
     "generate:docker": "docker build --tag asyncapi/studio .",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "release": "npm run generate:docker && semantic-release",
-    "postinstall": "npm run generate:template-parameters",
     "prepublishOnly": "npm run build && npm run generate:readme:toc"
   },
   "browserslist": {

--- a/src/services/specification.service.ts
+++ b/src/services/specification.service.ts
@@ -9,7 +9,6 @@ import avroSchemaParser from '@asyncapi/avro-schema-parser';
 import specs from '@asyncapi/specs';
 
 import { EditorService } from './editor.service';
-import { FormatService } from './format.service';
 import { MonacoService } from './monaco.service';
 
 import state from '../state';
@@ -61,12 +60,12 @@ export class SpecificationService {
     spec: string,
     version: string = this.getLastVersion(),
   ): Promise<string> {
-    const language = FormatService.retrieveLangauge(spec);
     try {
-      const convertedSpec = convert(spec, version);
-      return language === 'json'
-        ? FormatService.convertToJSON(convertedSpec)
-        : convertedSpec;
+      const converted = convert(spec, version);
+      if (typeof converted === 'object') {
+        return JSON.stringify(converted, undefined, 2);
+      }
+      return converted;
     } catch (err) {
       console.error(err);
       throw err;
@@ -185,7 +184,7 @@ export class SpecificationService {
     );
   }
 
-  private static isNotSupportedVersion(rawSpec: string): boolean {
+  static isNotSupportedVersion(rawSpec: string): boolean {
     if (this.notSupportedVersions.test(rawSpec.trim())) {
       return true;
     }

--- a/src/services/tests/specification.service.test.ts
+++ b/src/services/tests/specification.service.test.ts
@@ -13,15 +13,10 @@ describe('SpecificationService', () => {
     });
 
     test('should throw error if converter cannot convert spec - case with invalid version', async () => {
-      // disable console.error only for this test
-      jest.spyOn(console, 'error').mockImplementation(jest.fn());
-
       try {
         await SpecificationService.convertSpec('asyncapi: 1.3.0', '2.1.0');
-      } catch (e) {
-        expect(e).toEqual({
-          error: 'Cannot convert from 1.3.0 to 2.1.0.',
-        });
+      } catch (e: any) {
+        expect(e.message).toEqual('Cannot convert from 1.3.0 to 2.1.0.');
       }
     });
   });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- update `@asyncapi/converter` and `@asyncapi/react-component` to the latest version
- fix failing tests due to fact that `@asyncapi/converter` now handles the JSON spec 🚀 
- fix build of docker image, move `generate:template-parameters` script from `postinstall` to the `build` hook.

**Related issue(s)**
Fixes https://github.com/asyncapi/studio/pull/267
Fixes https://github.com/asyncapi/studio/pull/268
Fixes https://github.com/asyncapi/studio/pull/269
Fixes https://github.com/asyncapi/studio/pull/270