### PR TITLE
chore: remove github-bot from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @fmvilas @boyney123 @mcturco @magicmatatjahu @github-actions[bot]
+* @fmvilas @boyney123 @mcturco @magicmatatjahu


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Remove `github-bot` from codeowners.