### PR TITLE
fix: point to the latest version in ConvertToLatestModal

### DIFF
--- a/src/components/Modals/ConvertToLatestModal.tsx
+++ b/src/components/Modals/ConvertToLatestModal.tsx
@@ -114,7 +114,7 @@ export const ConvertToLatestModal: React.FunctionComponent = () => {
               onChange={e => setVersion(e.target.value)}
               value={version}
             >
-              <option value={latestVersion} key={latestVersion}>${latestVersion} (latest)</option>
+              <option value={latestVersion} key={latestVersion}>{latestVersion} (latest)</option>
               {reservedAllowedVersions.filter((v) => v !== latestVersion).map(v => (
                 <option key={v} value={v}  >
                   {v}

--- a/src/components/Modals/ConvertToLatestModal.tsx
+++ b/src/components/Modals/ConvertToLatestModal.tsx
@@ -76,7 +76,7 @@ export const ConvertToLatestModal: React.FunctionComponent = () => {
     <ConfirmModal
       title={convertOnlyToLatest ? 'Convert AsyncAPI document to latest version' : 'Convert AsyncAPI document to newest version'}
       confirmText={convertOnlyToLatest ? `Convert to ${latestVersion}` : 'Convert'}
-      confirmDisabled={convertOnlyToLatest ? false : !version || allowedVersions.length === 0}
+      confirmDisabled={false}
       cancelDisabled={forceConvert}
       show={show}
       onSubmit={onSubmit}
@@ -116,7 +116,7 @@ export const ConvertToLatestModal: React.FunctionComponent = () => {
             >
               <option value={latestVersion} key={latestVersion}>{latestVersion} (latest)</option>
               {reservedAllowedVersions.filter((v) => v !== latestVersion).map(v => (
-                <option key={v} value={v}  >
+                <option key={v} value={v}>
                   {v}
                 </option>
               ))}

--- a/src/components/Modals/ConvertToLatestModal.tsx
+++ b/src/components/Modals/ConvertToLatestModal.tsx
@@ -114,10 +114,10 @@ export const ConvertToLatestModal: React.FunctionComponent = () => {
               onChange={e => setVersion(e.target.value)}
               value={version}
             >
-              <option value="">Please Select</option>
-              {reservedAllowedVersions.map(v => (
-                <option key={v} value={v}>
-                  {v === latestVersion ? `${v} (latest)` : v}
+              <option value={latestVersion} key={latestVersion}>${latestVersion} (latest)</option>
+              {reservedAllowedVersions.filter((v) => v !== latestVersion).map(v => (
+                <option key={v} value={v}  >
+                  {v}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
**Description**
- ``` ConvertToLatesModal ``` takes the latest version of AsyncAPI as the default value

<img width="540" alt="image" src="https://user-images.githubusercontent.com/83456083/181045349-81ac97b2-f110-4a05-80c1-c623f2279de2.png">
Case shown in Screenshot- When the AsyncApi version is set to 1.0.0


**Related issue(s)**
Fixes #391 

