### PR TITLE
feat: import spec from file on editor init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG BASE_URL_PLACEHOLDER=189b303e-37a0-4f6f-8c0a-50333bc3c36e
 FROM docker.io/library/node:16.13.2 as build
 
 ARG BASE_URL_PLACEHOLDER
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 COPY package.json package-lock.json ./
 RUN npm install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ Run:
 
 ```bash
 docker run -it -p 8000:80 asyncapi/studio
+docker run -it -p 8000:80 -v "$(pwd)/another/path/to/asyncapi:/usr/share/nginx/html/docs/asyncapi" asyncapi/studio
 ```
 
 and then go to [http://localhost:8000](http://localhost:8000).
+
+Also feel free to check out the [docker-compose.yml](./docker-compose.yml) example.
 
 The `asyncapi/studio` image is based on the official `nginx` image.
 Please refer to the [Nginx documentation](https://registry.hub.docker.com/_/nginx/) to learn how to e.g. pass a custom `nginx` configuration or plug in additional volumes.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  async-studio:
+    build: .
+    container_name: events-api
+    restart: on-failure
+    ports:
+      - "8080:80"
+    volumes:
+      - ./public/docs/asyncapi:/usr/share/nginx/html/docs/asyncapi

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,6 @@ services:
     container_name: events-api
     restart: on-failure
     ports:
-      - "8080:80"
+      - "8000:80"
     volumes:
       - ./public/docs/asyncapi:/usr/share/nginx/html/docs/asyncapi

--- a/public/docs/asyncapi/asyncapi.yaml
+++ b/public/docs/asyncapi/asyncapi.yaml
@@ -1,0 +1,163 @@
+asyncapi: '2.4.0'
+info:
+  title: Streetlights Kafka API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+    ### Check out its awesome features:
+
+    * Turn a specific streetlight on/off 🌃
+    * Dim a specific streetlight 😎
+    * Receive real-time information about environmental lighting conditions 📈
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  test:
+    url: test.mykafkacluster.org:8092
+    protocol: kafka-secure
+    description: Test broker
+    security:
+      - saslScram: []
+
+defaultContentType: application/json
+
+channels:
+  smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/lightMeasured'
+
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.on:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOn
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.off:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOff
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting.streetlights.1.0.action.{streetlightId}.dim:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: dimLight
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/dimLight'
+
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+    turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
+      summary: Command a particular streetlight to turn the lights on or off.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/turnOnOffPayload"
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    turnOnOffPayload:
+      type: object
+      properties:
+        command:
+          type: string
+          enum:
+            - on
+            - off
+          description: Whether to turn on or off the light.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+
+  securitySchemes:
+    saslScram:
+      type: scramSha256
+      description: Provide your username and password for SASL/SCRAM authentication
+
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId: my-app-id

--- a/src/components/Editor/MonacoWrapper.tsx
+++ b/src/components/Editor/MonacoWrapper.tsx
@@ -28,6 +28,7 @@ export const MonacoWrapper: React.FunctionComponent<MonacoWrapperProps> = ({
     // save editor instance to the window
     window.Editor = editor;
     // parse on first run the spec
+    await EditorService.importFromURL('docs/asyncapi/asyncapi.yaml');
     SpecificationService.parseSpec(EditorService.getValue());
 
     // apply save command


### PR DESCRIPTION
**Description**

The purpose of this PR is to allow the users of the Studio Docker image to be able to initialise the container with the spec of their choice by providing a Docker bind mount.

**Related issue(s)**

Resolves [#403 ](https://github.com/asyncapi/studio/issues/403#issue-1345519106)