### PR TITLE
build: support arm64 architecture in docker image.

### DIFF
--- a/.github/workflows/if-nodejs-pr-testing.yml
+++ b/.github/workflows/if-nodejs-pr-testing.yml
@@ -33,6 +33,12 @@ jobs:
         id: packagejson
         run: test -e ./package.json && echo "::set-output name=exists::true" || echo "::set-output name=exists::false"
         shell: bash
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'linux/amd64,linux/arm64'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -80,6 +80,12 @@ jobs:
       - if: steps.packagejson.outputs.exists == 'true'
         name: Install dependencies
         run: npm install
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'linux/amd64,linux/arm64'
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - if: steps.packagejson.outputs.exists == 'true'
         name: Publish to any of NPM, Github, and Docker Hub
         id: release

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM docker.io/library/node:16.13.2 as build
 
 ARG BASE_URL_PLACEHOLDER
 
+# Skip puppeteer download since chromium isn't used by the project.
+ARG PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
+
 COPY package.json package-lock.json ./
 RUN npm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "generate:readme:toc": "markdown-toc -i README.md",
     "generate:assets": "npm run build && npm run generate:readme:toc",
     "generate:template-parameters": "ts-node ./scripts/template-parameters.ts",
-    "generate:docker": "docker build --tag asyncapi/studio .",
+    "generate:docker": "docker buildx build --platform linux/amd64,linux/arm64 --tag asyncapi/studio .",
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "release": "npm run generate:docker && semantic-release",
     "prepublishOnly": "npm run build && npm run generate:readme:toc"


### PR DESCRIPTION
**Description**

Support arm64 architecture in docker image.

- Chromium was skipped from puppeteer since it was already unused and it isn't compatible with `arm64`. Chromium would only be used to export a PDF of the HTML site, which is already unsupported. If support is required in the future, install chromium using the package manager of the image.
- Changes were tested in a Mac with M1 processor and worked successfully with local docker build.
- Changes to the github workflows are untested due to missing test environment.


Resolves #407