### PR TITLE
fix: force 'crypto.createHash()' to use SHA-256 (#360)

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,3 +1,8 @@
+// eslint-disable-next-line
+const crypto = require('crypto');         // Force method use SHA-256 to address
+const cryptCreateHashOrig = crypto.createHash;     // OpenSSL 3.0 deprecation of
+crypto.createHash = () => cryptCreateHashOrig('sha256');        // MD4 algorithm
+
 module.exports = {
   style: {
     postcss: {


### PR DESCRIPTION
This PR addresses error
```
Error: error:0308010C:digital envelope routines::unsupported
```
when starting AsyncAPI Studio with Node.js v17+.

TL;DR
webpack's hashing algorithm defaults to 'md4', which is deprecated in OpenSSL 3.0 used by Node.js v17+, so it's force-changed to 'sha256'.


The origin of the error is
```
This error is because node.js 17 uses OpenSSL3, which has changed code for
initialization context of md family (including md4), and this is a breaking
change.
```
https://itsmycode.com/error-digital-envelope-routines-unsupported *

A quick workaround for this error would be to specify `NODE_OPTIONS=--openssl-legacy-provider` in `package.json`
```
"start": "cross-env DISABLE_ESLINT_PLUGIN=true NODE_OPTIONS=--openssl-legacy-provider craco start",
```
or alternatively, to set an environmental variable in shell with `export`
```bash
export NODE_OPTIONS="--openssl-legacy-provider"
```
but deeper look into this error had shown that it is `webpack` who causes it:

```
> webpack 4 is using long time deprecated hash functions (like md4).
> Recent versions of webpack have fixed this.

Webpack 5.65 is uploaded to unstable, closing this bug.
```
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1011097#17

and, yet again BUT, `webpack` 5 documentation still reads:
```
The hashing algorithm to use, defaults to 'md4'.
```
https://webpack.js.org/plugins/hashed-module-ids-plugin

When using obvious approach, `webpack` 4 (used in `studio`) refused to accept `craco`'s override of configuration
```js
webpackConfig.output = {
  ...webpackConfig.output,
  hashFunction: 'sha256',
};
```

And to make things more interesting, Node.js' command-line option `--openssl-legacy-provider` [appeared only in v17.0.0](https://nodejs.org/api/cli.html#--openssl-legacy-provider), causing Nodes up to v16.17.0 to spit error
```
node: --openssl-legacy-provider is not allowed in NODE_OPTIONS
```
thus making solution of `npm`'s start script modification completely unsuitable for addressing both Node.js v17+ and v16-.

So instead of modifying `npm`'s start script or overriding webpack's `output.hashFunction`, the `craco`'s override mechanism was used to change the webpack's hashing algorithm by overriding Node.js' `crypto.createHash()` method itself.

Fixes https://github.com/asyncapi/studio/issues/360

\* Detailed explanation from the OpenSSL wiki:
```
The legacy provider.
This is a collection of legacy algorithms that are either no longer in common
use or strongly discouraged from use. However some applications may need to use
these algorithms for backwards compatibility reasons. This provider is NOT
loaded by default. This may mean that some applications upgrading from earlier
versions of OpenSSL may find that some algorithms are no longer available
unless they load the legacy provider explicitly. Algorithms in the legacy 
provider include MD2, MD4, MDC2, RMD160, CAST5, BF (Blowfish), IDEA, SEED, RC2,
RC4, RC5 and DES (but not 3DES).
```
https://wiki.openssl.org/index.php/OpenSSL_3.0
