### PR TITLE
Extract assignment of `elementsGrouped[element?.data.groupId]`

### DIFF
--- a/src/components/Visualiser/utils/node-calculator.ts
+++ b/src/components/Visualiser/utils/node-calculator.ts
@@ -3,9 +3,12 @@ import { isNode, Node } from 'react-flow-renderer';
 const groupNodesByColumn = (elements: Node[]) => {
   return elements.reduce((elementsGrouped: any, element: Node) => {
     if (isNode(element) && element.__rf) {
+      const assignElementsGrouped = () => {
+        elementsGrouped[element?.data.groupId] = [element];
+      };
       return {
         ...elementsGrouped,
-        [element.data.columnToRenderIn]: elementsGrouped[element?.data.columnToRenderIn] ? elementsGrouped[element?.data.columnToRenderIn].concat([element]) : (elementsGrouped[element?.data.groupId] = [element]),
+        [element.data.columnToRenderIn]: elementsGrouped[element?.data.columnToRenderIn] ? elementsGrouped[element?.data.columnToRenderIn].concat([element]) : assignElementsGrouped(),
       };
     }
     return elementsGrouped;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- As mentioned in issue #446, assignments within sub-expressions are less readable and may have side effects.
- Created a function `assignElementsGrouped` that handles the assignment of `elementsGrouped[element?.data.groupId]`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Resolves #446 