### PR TITLE
refactor: simplify state management, part 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "react-dom": "^18.2.0",
         "react-hot-toast": "2.4.0",
         "react-icons": "^4.6.0",
-        "reactflow": "^11.2.0"
+        "reactflow": "^11.2.0",
+        "zustand": "^4.1.4"
       },
       "devDependencies": {
         "@asyncapi/dotnet-nats-template": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-dom": "^18.2.0",
     "react-hot-toast": "2.4.0",
     "react-icons": "^4.6.0",
-    "reactflow": "^11.2.0"
+    "reactflow": "^11.2.0",
+    "zustand": "^4.1.4"
   },
   "scripts": {
     "dev": "npm run start",

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import SplitPane from './SplitPane';
 import { Editor } from './Editor/Editor';
 import { Navigation } from './Navigation';
@@ -8,17 +6,19 @@ import { NewFileModal, RedirectedModal } from './Modals';
 import { VisualiserTemplate } from './Visualiser';
 
 import { debounce } from '../helpers';
-import state from '../state';
+import { usePanelsState } from '../state/index.state';
+
+import type { FunctionComponent } from 'react';
 
 interface ContentProps {}
 
-export const Content: React.FunctionComponent<ContentProps> = () => { // eslint-disable-line sonarjs/cognitive-complexity
-  const sidebarState = state.useSidebarState();
+export const Content: FunctionComponent<ContentProps> = () => { // eslint-disable-line sonarjs/cognitive-complexity
+  const { show, secondaryPanelType } = usePanelsState();
 
-  const navigationEnabled = sidebarState.panels.navigation.get();
-  const editorEnabled = sidebarState.panels.editor.get();
-  const viewEnabled = sidebarState.panels.view.get();
-  const viewType = sidebarState.panels.viewType.get();
+  const navigationEnabled = show.primarySidebar;
+  const editorEnabled = show.primaryPanel;
+  const viewEnabled = show.secondaryPanel;
+  const viewType = secondaryPanelType;
 
   const splitPosLeft = 'splitPos:left';
   const splitPosRight = 'splitPos:right';

--- a/src/components/Modals/NewFileModal.tsx
+++ b/src/components/Modals/NewFileModal.tsx
@@ -1,21 +1,24 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { BsFillCheckCircleFill } from 'react-icons/bs';
 import toast from 'react-hot-toast';
 
-import { ConfirmModal } from './index';
 import examples from '../../examples';
+
+import { ConfirmModal } from './ConfirmModal';
 import { useServices } from '../../services';
-import state from '../../state';
+import { usePanelsState, panelsState } from '../../state/index.state';
+
+import type { ComponentType, MouseEventHandler, FunctionComponent } from 'react';
 
 interface TemplateListItemProps {
   title: string;
-  description: React.ComponentType;
+  description: ComponentType;
   isSelected: boolean;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick: MouseEventHandler<HTMLButtonElement>;
   key: string;
 }
 
-const TemplateListItem: React.FunctionComponent<TemplateListItemProps> = ({ title, description: Description, onClick, isSelected }) => {
+const TemplateListItem: FunctionComponent<TemplateListItemProps> = ({ title, description: Description, onClick, isSelected }) => {
   const containerStyles = isSelected ? 'border-pink-500' : 'border-gray-200';
   const textStyles = isSelected ? 'text-pink-600' : 'text-gray-600';
 
@@ -32,15 +35,14 @@ const TemplateListItem: React.FunctionComponent<TemplateListItemProps> = ({ titl
   );
 };
 
-export const NewFileModal: React.FunctionComponent = () => {
+export const NewFileModal: FunctionComponent = () => {
   const { editorSvc } = useServices();
-  const sidebarState = state.useSidebarState();
-  const newFileEnabled = sidebarState.panels.newFile.get();
+  const newFileOpened = usePanelsState(state => state.newFileOpened);
   const [selectedTemplate, setSelectedTemplate] = useState({ title: '', template: '' });
 
   const onSubmit = () => {
     editorSvc.updateState({ content: selectedTemplate.template, updateModel: true });
-    sidebarState.panels.newFile.set(false);
+    panelsState.setState({ newFileOpened: false });
     setSelectedTemplate({ title: '', template: '' });
 
     toast.success(
@@ -51,7 +53,7 @@ export const NewFileModal: React.FunctionComponent = () => {
   };
 
   const onCancel = () => {
-    sidebarState.panels.newFile.set(false);
+    panelsState.setState({ newFileOpened: false });
     setSelectedTemplate({ title: '', template: '' });
   };
 
@@ -64,7 +66,7 @@ export const NewFileModal: React.FunctionComponent = () => {
       title="AsyncAPI Templates - Start with our template examples"
       confirmText="Use Template"
       confirmDisabled={!selectedTemplate.template}
-      show={newFileEnabled}
+      show={newFileOpened}
       onSubmit={onSubmit}
       onCancel={onCancel}
     >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,7 +32,7 @@ function updateState(panelName: keyof PanelsState['show'], type?: PanelsState['s
   }
 
   panelsState.setState({
-    show: { ...newShow },
+    show: newShow,
     secondaryPanelType,
   });
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,21 +9,22 @@ import type { FunctionComponent, ReactNode } from 'react';
 import type { PanelsState } from '../state/panels.state';
 
 function updateState(panelName: keyof PanelsState['show'], type?: PanelsState['secondaryPanelType']) {
-  let { show, secondaryPanelType } = panelsState.getState();
-  const newShow = { ...show };
+  const settingsState = panelsState.getState();
+  let secondaryPanelType = settingsState.secondaryPanelType;
+  const newShow = { ...settingsState.show };
 
   if (type === 'template' || type === 'visualiser') {
     // on current type
     if (secondaryPanelType === type) {
-      newShow[panelName] = !newShow[panelName];
+      newShow[`${panelName}`] = !newShow[`${panelName}`];
     } else {
       secondaryPanelType = type;
-      if (newShow[panelName] === false) {
-        newShow[panelName] = true;
+      if (newShow[`${panelName}`] === false) {
+        newShow[`${panelName}`] = true;
       }
     }
   } else {
-    newShow[panelName] = !newShow[panelName];
+    newShow[`${panelName}`] = !newShow[`${panelName}`];
   }
 
   if (!newShow.primaryPanel && !newShow.secondaryPanel) {
@@ -33,7 +34,7 @@ function updateState(panelName: keyof PanelsState['show'], type?: PanelsState['s
   panelsState.setState({
     show: { ...newShow },
     secondaryPanelType,
-  })
+  });
 }
 
 interface NavItem {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,84 +1,75 @@
-import React from 'react';
 import { VscListSelection, VscCode, VscOpenPreview, VscGraph, VscNewFile } from 'react-icons/vsc';
 
 import { Tooltip } from './common';
 import { SettingsModal } from './Modals/Settings/SettingsModal';
 
-import state from '../state';
+import { usePanelsState, panelsState } from '../state/index.state';
 
-type NavItemType = 'navigation' | 'editor' | 'template' | 'visualiser';
+import type { FunctionComponent, ReactNode } from 'react';
+import type { PanelsState } from '../state/panels.state';
 
-function setActiveNav(navItem: NavItemType) {
-  const panels = state.sidebar.panels;
-  const panelsState = panels.get();
+function updateState(panelName: keyof PanelsState['show'], type?: PanelsState['secondaryPanelType']) {
+  let { show, secondaryPanelType } = panelsState.getState();
+  const newShow = { ...show };
 
-  const newState = {
-    ...panelsState,
-  };
-
-  if (navItem === 'template' || navItem === 'visualiser') {
+  if (type === 'template' || type === 'visualiser') {
     // on current type
-    if (newState.viewType === navItem) {
-      newState.view = !newState.view;
+    if (secondaryPanelType === type) {
+      newShow[panelName] = !newShow[panelName];
     } else {
-      newState.viewType = navItem;
-      if (newState.view === false) {
-        newState.view = true;
+      secondaryPanelType = type;
+      if (newShow[panelName] === false) {
+        newShow[panelName] = true;
       }
     }
   } else {
-    newState[`${navItem}`] = !newState[`${navItem}`];
+    newShow[panelName] = !newShow[panelName];
   }
 
-  if (newState.navigation && !newState.editor && !newState.view) {
-    panels.set({
-      ...newState,
-      view: true,
-    });
-    return;
-  }
-  if (!Object.values(newState).some(itemNav => itemNav === true)) {
-    panels.set({
-      ...newState,
-      view: true,
-    });
-    return;
+  if (!newShow.primaryPanel && !newShow.secondaryPanel) {
+    newShow.secondaryPanel = true;
   }
 
-  panels.set(newState);
+  panelsState.setState({
+    show: { ...newShow },
+    secondaryPanelType,
+  })
 }
 
 interface NavItem {
   name: string;
   title: string;
-  isActive: () => boolean;
-  icon: React.ReactNode;
-  tooltip: React.ReactNode;
+  isActive: boolean;
+  updateState?: () => void;
+  icon: ReactNode;
+  tooltip: ReactNode;
 }
 
 interface SidebarProps {}
 
-export const Sidebar: React.FunctionComponent<SidebarProps> = () => {
-  const sidebarState = state.useSidebarState();
+export const Sidebar: FunctionComponent<SidebarProps> = () => {
+  const { show, secondaryPanelType } = usePanelsState();
 
-  if (sidebarState.show.get() === false) {
+  if (show.activityBar === false) {
     return null;
   }
 
   const navigation: NavItem[] = [
     // navigation
     {
-      name: 'navigation',
+      name: 'primarySidebar',
       title: 'Navigation',
-      isActive: () => sidebarState.panels.navigation.get(),
+      isActive: show.primarySidebar,
+      updateState: () => updateState('primarySidebar'),
       icon: <VscListSelection className="w-5 h-5" />,
       tooltip: 'Navigation',
     },
     // editor
     {
-      name: 'editor',
+      name: 'primaryPanel',
       title: 'Editor',
-      isActive: () => sidebarState.panels.editor.get(),
+      isActive: show.primaryPanel,
+      updateState: () => updateState('primaryPanel'),
       icon: <VscCode className="w-5 h-5" />,
       tooltip: 'Editor',
     },
@@ -86,7 +77,8 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = () => {
     {
       name: 'template',
       title: 'Template',
-      isActive: () => sidebarState.panels.view.get() && sidebarState.panels.viewType.get() === 'template',
+      isActive: show.secondaryPanel && secondaryPanelType === 'template',
+      updateState: () => updateState('secondaryPanel', 'template'),
       icon: <VscOpenPreview className="w-5 h-5" />,
       tooltip: 'HTML preview',
     },
@@ -94,7 +86,8 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = () => {
     {
       name: 'visualiser',
       title: 'Visualiser',
-      isActive: () => sidebarState.panels.view.get() && sidebarState.panels.viewType.get() === 'visualiser',
+      isActive: show.secondaryPanel && secondaryPanelType === 'visualiser',
+      updateState: () => updateState('secondaryPanel', 'visualiser'),
       icon: <VscGraph className="w-5 h-5" />,
       tooltip: 'Blocks visualiser',
     },
@@ -102,7 +95,8 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = () => {
     {
       name: 'newFile',
       title: 'New file',
-      isActive: () => false,
+      isActive: false,
+      updateState: () => panelsState.setState({ newFileOpened: true }),
       icon: <VscNewFile className="w-5 h-5" />,
       tooltip: 'New file',
     },
@@ -115,11 +109,11 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = () => {
           <Tooltip content={item.tooltip} placement='right' hideOnClick={true} key={item.name}>
             <button
               title={item.title}
-              onClick={() => setActiveNav(item.name as NavItemType)}
+              onClick={() => item.updateState?.()}
               className={'flex text-sm focus:outline-none border-box p-2'}
               type="button"
             >
-              <div className={item.isActive() ? 'bg-gray-600 p-2 rounded text-white' : 'p-2 text-gray-500 hover:text-white'}>
+              <div className={item.isActive ? 'bg-gray-600 p-2 rounded text-white' : 'p-2 text-gray-500 hover:text-white'}>
                 {item.icon}
               </div>
             </button>

--- a/src/services/converter.service.ts
+++ b/src/services/converter.service.ts
@@ -1,0 +1,26 @@
+import { AbstractService } from './abstract.service';
+
+import { convert } from '@asyncapi/converter';
+
+import type { ConvertVersion, ConvertOptions } from '@asyncapi/converter';
+
+export class ConverterService extends AbstractService {
+  async convert(
+    spec: string,
+    version?: ConvertVersion,
+    options?: ConvertOptions,
+  ): Promise<string> {
+    version = version || this.svcs.specificationSvc.getLastVersion();
+
+    try {
+      const converted = convert(spec, version, options);
+      if (typeof converted === 'object') {
+        return JSON.stringify(converted, undefined, 2);
+      }
+      return converted;
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  }
+}

--- a/src/services/parser.service.ts
+++ b/src/services/parser.service.ts
@@ -71,7 +71,7 @@ export class ParserService extends AbstractService {
   getRangeForJsonPath(uri: string, jsonPath: string | Array<string | number>) {
     try {
       const { documents } = documentsState.getState();
-      const extras = documents[uri]?.extras;
+      const extras = documents[String(uri)]?.extras;
       if (extras) {
         jsonPath = Array.isArray(jsonPath) ? jsonPath : jsonPath.split('/').map(untilde);
         if (jsonPath[0] === '') jsonPath.shift();
@@ -104,7 +104,7 @@ export class ParserService extends AbstractService {
       const oldFiles = prevState.files;
 
       Object.entries(newFiles).forEach(([uri, file]) => {
-        const oldFile = oldFiles[uri];
+        const oldFile = oldFiles[String(uri)];
         if (file === oldFile) return;
         this.parse(uri, file.content);
       });

--- a/src/services/parser.service.ts
+++ b/src/services/parser.service.ts
@@ -1,0 +1,133 @@
+import { AbstractService } from './abstract.service';
+
+import { Parser, convertToOldAPI, DiagnosticSeverity } from '@asyncapi/parser/cjs';
+import { OpenAPISchemaParser } from '@asyncapi/parser/cjs/schema-parser/openapi-schema-parser';
+import { AvroSchemaParser } from '@asyncapi/parser/cjs/schema-parser/avro-schema-parser';
+import { untilde } from '@asyncapi/parser/cjs/utils';
+
+import { isDeepEqual } from '../helpers';
+import { filesState, documentsState, settingsState } from '../state/index.state';
+
+import type { Diagnostic, ParseOptions } from '@asyncapi/parser/cjs';
+
+export class ParserService extends AbstractService {
+  private parser!: Parser;
+
+  override async onInit() {
+    this.parser = new Parser({
+      schemaParsers: [
+        OpenAPISchemaParser(),
+        AvroSchemaParser(),
+      ],
+      __unstable: {
+        resolver: {
+          cache: false,
+        }
+      }
+    });
+
+    this.subscribeToFiles();
+    this.subscribeToSettings();
+    this.parseSavedDocuments();
+  }
+
+  async parse(uri: string, spec: string, options: ParseOptions = {}): Promise<void> {
+    if (!options.source) {
+      options.source = uri;
+    }
+
+    const { updateDocument } = documentsState.getState();
+    let diagnostics: Diagnostic[] = [];
+
+    try {
+      const { document, diagnostics: _diagnostics,  extras } = await this.parser.parse(spec, options);
+      diagnostics = this.filterDiagnostics(_diagnostics);
+  
+      if (document) {
+        const oldDocument = convertToOldAPI(document);
+        updateDocument(uri, {
+          uri,
+          document: oldDocument,
+          diagnostics,
+          extras,
+          valid: true,
+        });
+        return;
+      } 
+    } catch (err: unknown) {
+      console.log(err);
+      diagnostics = [];
+    }
+
+    updateDocument(uri, {
+      uri,
+      document: undefined,
+      diagnostics,
+      extras: undefined,
+      valid: false,
+    });
+  }
+
+  getRangeForJsonPath(uri: string, jsonPath: string | Array<string | number>) {
+    try {
+      const { documents } = documentsState.getState();
+      const extras = documents[uri]?.extras;
+      if (extras) {
+        jsonPath = Array.isArray(jsonPath) ? jsonPath : jsonPath.split('/').map(untilde);
+        if (jsonPath[0] === '') jsonPath.shift();
+        return extras.document.getRangeForJsonPath(jsonPath, true);
+      }
+    } catch (err: any) {
+      return;
+    }
+  }
+
+  filterDiagnostics(diagnostics: Diagnostic[]) {
+    const { governance: { show } } = settingsState.getState();
+    return diagnostics.filter(({ severity }) => {
+      return (
+        severity === DiagnosticSeverity.Error ||
+        (severity === DiagnosticSeverity.Warning && show.warnings) ||
+        (severity === DiagnosticSeverity.Information && show.informations) ||
+        (severity === DiagnosticSeverity.Hint && show.hints)
+      );
+    });
+  }
+
+  filterDiagnosticsBySeverity(diagnostics: Diagnostic[], severity: DiagnosticSeverity) {
+    return diagnostics.filter(diagnostic => diagnostic.severity === severity);
+  }
+
+  private subscribeToFiles() {
+    filesState.subscribe((state, prevState) => {
+      const newFiles = state.files;
+      const oldFiles = prevState.files;
+
+      Object.entries(newFiles).forEach(([uri, file]) => {
+        const oldFile = oldFiles[uri];
+        if (file === oldFile) return;
+        this.parse(uri, file.content);
+      });
+    });
+  }
+
+  private subscribeToSettings() {
+    settingsState.subscribe((state, prevState) => {
+      if (isDeepEqual(state.governance, prevState.governance)) return;
+
+      const { files } = filesState.getState();
+      Object.entries(files).forEach(([uri, file]) => {
+        this.parse(uri, file.content);
+      });
+    });
+  }
+
+  private parseSavedDocuments() {
+    const { files } = filesState.getState();
+    return Promise.all(
+      Object.entries(files).map(([uri, file]) => {
+        return this.parse(uri, file.content);
+      }),
+    );
+  }
+}

--- a/src/services/settings.service.ts
+++ b/src/services/settings.service.ts
@@ -1,0 +1,20 @@
+import { AbstractService } from './abstract.service';
+
+import { isDeepEqual } from '../helpers';
+import { settingsState } from '../state/index.state';
+
+import type { SettingsState } from '../state/settings.state';
+
+export class SettingsService extends AbstractService {
+  get(): SettingsState {
+    return settingsState.getState();
+  }
+
+  set(state: Partial<SettingsState>) {
+    settingsState.setState(state);
+  }
+
+  isEqual(newState: Partial<SettingsState>): boolean {
+    return isDeepEqual(this.get(), newState);
+  }
+}

--- a/src/state/app.state.ts
+++ b/src/state/app.state.ts
@@ -1,0 +1,17 @@
+import create from 'zustand'
+
+export type AppState = {
+  initialized: boolean;
+  readOnly: boolean;
+  liveServer: boolean;
+  redirectedFrom: string | false;
+}
+
+export const appState = create<AppState>(_ => ({
+  initialized: false,
+  readOnly: false,
+  liveServer: false,
+  redirectedFrom: false,
+}));
+
+export const useAppState = appState;

--- a/src/state/app.state.ts
+++ b/src/state/app.state.ts
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import create from 'zustand';
 
 export type AppState = {
   initialized: boolean;
@@ -7,7 +7,7 @@ export type AppState = {
   redirectedFrom: string | false;
 }
 
-export const appState = create<AppState>(_ => ({
+export const appState = create<AppState>(() => ({
   initialized: false,
   readOnly: false,
   liveServer: false,

--- a/src/state/documents.state.ts
+++ b/src/state/documents.state.ts
@@ -1,0 +1,28 @@
+import create from 'zustand';
+
+import type { OldAsyncAPIDocument as AsyncAPIDocument, Diagnostic, ParseOutput } from '@asyncapi/parser/cjs';
+
+export type Document = {
+  uri: string;
+  document?: AsyncAPIDocument;
+  extras?: ParseOutput['extras'];
+  diagnostics: Diagnostic[];
+  valid?: boolean;
+}
+
+export type DocumentsState = {
+  documents: Record<string, Document>; 
+}
+
+export type DocumentsActions = {
+  updateDocument: (uri: string, document: Partial<Document>) => void;
+}
+
+export const documentsState = create<DocumentsState & DocumentsActions>((set) => ({
+  documents: {},
+  updateDocument(uri: string, document: Partial<Document>) {
+    set(state => ({ documents: { ...state.documents, [uri]: { ...state.documents[uri] || {}, ...document } } }));
+  },
+}));
+
+export const useDocumentsState = documentsState;

--- a/src/state/documents.state.ts
+++ b/src/state/documents.state.ts
@@ -18,10 +18,10 @@ export type DocumentsActions = {
   updateDocument: (uri: string, document: Partial<Document>) => void;
 }
 
-export const documentsState = create<DocumentsState & DocumentsActions>((set) => ({
+export const documentsState = create<DocumentsState & DocumentsActions>(set => ({
   documents: {},
   updateDocument(uri: string, document: Partial<Document>) {
-    set(state => ({ documents: { ...state.documents, [uri]: { ...state.documents[uri] || {}, ...document } } }));
+    set(state => ({ documents: { ...state.documents, [String(uri)]: { ...state.documents[String(uri)] || {}, ...document } } }));
   },
 }));
 

--- a/src/state/files.state.ts
+++ b/src/state/files.state.ts
@@ -178,7 +178,7 @@ export const filesState = create(
   persist<FilesState & FilesActions>(set => 
     ({
       files: {
-        'asyncapi': {
+        asyncapi: {
           uri: 'asyncapi',
           name: 'asyncapi',
           content: schema,
@@ -190,13 +190,13 @@ export const filesState = create(
         }
       },
       updateFile(uri: string, file: Partial<File>) {
-        set(state => ({ files: { ...state.files, [uri]: { ...state.files[uri] || {}, ...file } } }));
+        set(state => ({ files: { ...state.files, [String(uri)]: { ...state.files[String(uri)] || {}, ...file } } }));
       },
     }), 
-    {
-      name: 'studio-files',
-      getStorage: () => localStorage,
-    }
+  {
+    name: 'studio-files',
+    getStorage: () => localStorage,
+  }
   ),
 );
 

--- a/src/state/files.state.ts
+++ b/src/state/files.state.ts
@@ -1,0 +1,203 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+const schema =
+  localStorage.getItem('document') || `asyncapi: '2.5.0'
+info:
+  title: Streetlights Kafka API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+    ### Check out its awesome features:
+    * Turn a specific streetlight on/off 🌃
+    * Dim a specific streetlight 😎
+    * Receive real-time information about environmental lighting conditions 📈
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+servers:
+  test:
+    url: test.mykafkacluster.org:8092
+    protocol: kafka-secure
+    description: Test broker
+    security:
+      - saslScram: []
+defaultContentType: application/json
+channels:
+  smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/lightMeasured'
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.on:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOn
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+  smartylighting.streetlights.1.0.action.{streetlightId}.turn.off:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOff
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+  smartylighting.streetlights.1.0.action.{streetlightId}.dim:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: dimLight
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/dimLight'
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      contentType: application/json
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+    turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
+      summary: Command a particular streetlight to turn the lights on or off.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/turnOnOffPayload"
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    turnOnOffPayload:
+      type: object
+      properties:
+        command:
+          type: string
+          enum:
+            - on
+            - off
+          description: Whether to turn on or off the light.
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+  securitySchemes:
+    saslScram:
+      type: scramSha256
+      description: Provide your username and password for SASL/SCRAM authentication
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId: my-app-id
+`;
+
+export interface FileStat {
+  mtime: number;
+}
+
+export type File = {
+  uri: string;
+  name: string;
+  content: string;
+  language: 'json' | 'yaml';
+  modified: boolean;
+  stat?: FileStat;
+}
+
+export type FilesState = {
+  files: Record<string, File>;
+}
+
+export type FilesActions = {
+  updateFile: (uri: string, file: Partial<File>) => void;
+}
+
+export const filesState = create(
+  persist<FilesState & FilesActions>(set => 
+    ({
+      files: {
+        'asyncapi': {
+          uri: 'asyncapi',
+          name: 'asyncapi',
+          content: schema,
+          language: 'yaml',
+          modified: false,
+          stat: {
+            mtime: (new Date()).getTime(),
+          }
+        }
+      },
+      updateFile(uri: string, file: Partial<File>) {
+        set(state => ({ files: { ...state.files, [uri]: { ...state.files[uri] || {}, ...file } } }));
+      },
+    }), 
+    {
+      name: 'studio-files',
+      getStorage: () => localStorage,
+    }
+  ),
+);
+
+export const useFilesState = filesState;

--- a/src/state/index.state.ts
+++ b/src/state/index.state.ts
@@ -1,0 +1,37 @@
+import { appState, useAppState } from './app.state';
+import { documentsState, useDocumentsState } from './documents.state';
+import { filesState, useFilesState } from './files.state';
+import { panelsState, usePanelsState } from './panels.state';
+import { settingsState, useSettingsState } from './settings.state';
+
+export { 
+  appState, useAppState,
+  documentsState, useDocumentsState,
+  filesState, useFilesState,
+  panelsState, usePanelsState,
+  settingsState, useSettingsState,
+};
+
+const state = {
+  // app
+  app: appState,
+  useAppState,
+
+  // documents
+  documents: documentsState,
+  useDocumentsState,
+
+  // file-system
+  files: filesState,
+  useFilesState,
+
+  // panels
+  panels: panelsState,
+  usePanelsState,
+
+  // settings
+  settings: settingsState,
+  useSettingsState,
+};
+
+export default state;

--- a/src/state/panels.state.ts
+++ b/src/state/panels.state.ts
@@ -17,7 +17,7 @@ export type PanelsState = {
 }
 
 export const panelsState = create(
-  persist<PanelsState>(_ => 
+  persist<PanelsState>(() => 
     ({
       show: {
         activityBar: true,
@@ -31,10 +31,10 @@ export const panelsState = create(
       secondaryPanelType: 'template',
       newFileOpened: false,
     }), 
-    {
-      name: 'studio-panels',
-      getStorage: () => localStorage,
-    }
+  {
+    name: 'studio-panels',
+    getStorage: () => localStorage,
+  }
   ),
 );
 

--- a/src/state/panels.state.ts
+++ b/src/state/panels.state.ts
@@ -1,0 +1,41 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type PanelsState = {
+  show: {
+    activityBar: boolean;
+    statusBar: boolean;
+    primarySidebar: boolean;
+    secondarySidebar: boolean;
+    primaryPanel: boolean;
+    secondaryPanel: boolean;
+    contextPanel: boolean;
+  };
+  // TODO: remove when panels tabs will be introduced
+  secondaryPanelType: 'template' | 'visualiser';
+  newFileOpened: boolean;
+}
+
+export const panelsState = create(
+  persist<PanelsState>(_ => 
+    ({
+      show: {
+        activityBar: true,
+        statusBar: true,
+        primarySidebar: true,
+        secondarySidebar: true,
+        primaryPanel: true,
+        secondaryPanel: true,
+        contextPanel: true,
+      },
+      secondaryPanelType: 'template',
+      newFileOpened: false,
+    }), 
+    {
+      name: 'studio-panels',
+      getStorage: () => localStorage,
+    }
+  ),
+);
+
+export const usePanelsState = panelsState;

--- a/src/state/settings.state.ts
+++ b/src/state/settings.state.ts
@@ -19,7 +19,7 @@ export type SettingsState = {
 }
 
 export const settingsState = create(
-  persist<SettingsState>(_ => 
+  persist<SettingsState>(() => 
     ({
       editor: {
         autoSaving: true,
@@ -36,10 +36,10 @@ export const settingsState = create(
         autoRendering: true,
       },
     }), 
-    {
-      name: 'studio-settings',
-      getStorage: () => localStorage,
-    }
+  {
+    name: 'studio-settings',
+    getStorage: () => localStorage,
+  }
   ),
 );
 

--- a/src/state/settings.state.ts
+++ b/src/state/settings.state.ts
@@ -1,0 +1,46 @@
+import create from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type SettingsState = {
+  editor: {
+    autoSaving: boolean;
+    savingDelay: number;
+  };
+  governance: {
+    show: {
+      warnings: boolean;
+      informations: boolean;
+      hints: boolean;
+    }
+  };
+  templates: {
+    autoRendering: boolean;
+  };
+}
+
+export const settingsState = create(
+  persist<SettingsState>(_ => 
+    ({
+      editor: {
+        autoSaving: true,
+        savingDelay: 625,
+      },
+      governance: {
+        show: {
+          warnings: true,
+          informations: true,
+          hints: true,
+        },
+      },
+      templates: {
+        autoRendering: true,
+      },
+    }), 
+    {
+      name: 'studio-settings',
+      getStorage: () => localStorage,
+    }
+  ),
+);
+
+export const useSettingsState = settingsState;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- start using `zustand` library for state management
- now, new state "doesn't" work, it means that old state and new state coexist in one source code - I don't wanna make huge PR with everything so I split code to few separate PRs.
- update (in this PR) two components with new state management
- old state management (based on proxies) will be removed in the next PR, where will be also update of components with new state 

That PR is a part of refactoring of the Studio to support multiple files.