### PR TITLE
fix: possibility of moving blocks in visualiser

### DIFF
--- a/src/components/Visualiser/Controls.tsx
+++ b/src/components/Visualiser/Controls.tsx
@@ -25,7 +25,7 @@ export const Controls: FunctionComponent<ControlsProps> = () => {
   }, [animateNodes]);
 
   const reloadInterface = () => {
-    setNodes([...calculateNodesForDynamicLayout(nodes)]);
+    setNodes(calculateNodesForDynamicLayout(nodes));
     fitView();
   };
 

--- a/src/components/Visualiser/utils/node-calculator.ts
+++ b/src/components/Visualiser/utils/node-calculator.ts
@@ -22,7 +22,7 @@ export const calculateNodesForDynamicLayout = (elements: Node[]) => {
   const elementsGroupedByColumn = groupNodesByColumn(elements);
 
   const newElements: { nodes: Node[], currentXPosition: number } = Object.keys(elementsGroupedByColumn).reduce(
-    (data: any, group: string) => {
+    (data: { nodes: Node[], currentXPosition: number }, group: string) => {
       const groupNodes = elementsGroupedByColumn[String(group)];
 
       // eslint-disable-next-line
@@ -35,24 +35,21 @@ export const calculateNodesForDynamicLayout = (elements: Node[]) => {
 
       // For each group (column), render the nodes based on height they require (with some padding)
       const { positionedNodes } = groupNodes.reduce(
-        (groupedNodes: any, currentNode: Node) => {
+        (groupedNodes: { positionedNodes: Node[], currentYPosition: number }, currentNode: Node) => {
           const verticalPadding = 40;
 
-          currentNode.position = {
-            x: data.currentXPosition,
-            y: groupedNodes.currentYPosition,
-          };
+          currentNode.position.x = data.currentXPosition;
+          currentNode.position.y = groupedNodes.currentYPosition;
 
           return {
             positionedNodes: groupedNodes.positionedNodes.concat([currentNode]),
-            currentYPosition: groupedNodes.currentYPosition + currentNode.height + verticalPadding,
+            currentYPosition: groupedNodes.currentYPosition + (currentNode.height || 0) + verticalPadding,
           };
         },
         { positionedNodes: [], currentYPosition: 0 }
       );
 
       return {
-        ...data,
         nodes: [...data.nodes, ...positionedNodes],
         currentXPosition: data.currentXPosition + maxWidthOfColumn + 100,
       };


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

I found some weird bug: if we wanna move some block in visualiser, then in some cases it doesn't work and it can be possible to see "jumping" of the blocks between renders - from initial position to the destination. That PR fix that. Problem probably occurred through bumping the `react-flow-renderer` dep to the v11 version.