### PR TITLE
fix: comment mentioning the tutorial

### DIFF
--- a/src/examples/tutorials/invalid.yml
+++ b/src/examples/tutorials/invalid.yml
@@ -1,3 +1,5 @@
+# The purpose of this invalid file is only for learning and if you came across it, here's the tutorial https://www.asyncapi.com/docs/tutorials/validate-documents
+
 asyncapi: '1.0.0'
 info:
   title: Streetlights API


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Refer - we could add a comment within the template that links to the tutorial. That way, users who accidentally run into this while using the Studio tool can immediately see we have a tutorial for learning how to debug their documents. https://github.com/asyncapi/website/pull/1022#issuecomment-1354032705

- also the link I have added is the link after the tutorial PR gets merged in future and not current deployed one as we have to change again
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->