### PR TITLE
feat: add IBM MQ template

### DIFF
--- a/src/components/Modals/NewFileModal.tsx
+++ b/src/components/Modals/NewFileModal.tsx
@@ -45,7 +45,7 @@ export const NewFileModal = create(() => {
 
     toast.success(
       <div>
-        <span className="block text-bold">Succesfully reused the {`"${selectedTemplate.title}"`} template.</span>
+        <span className="block text-bold">Successfully reused the {`"${selectedTemplate.title}"`} template.</span>
       </div>
     );
   };

--- a/src/examples/ibmmq.yml
+++ b/src/examples/ibmmq.yml
@@ -1,0 +1,47 @@
+asyncapi: 2.6.0
+info:
+  title: Record Label Service
+  version: 1.1.0
+  description: This service is in charge of processing music
+  license:
+    name: Apache License 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+servers:
+  production:
+    url: 'ibmmq://localhost:1414/QM1/DEV.APP.SVRCONN'
+    protocol: ibmmq-secure
+    description: Production Instance 1
+    bindings:
+      ibmmq:
+        cipherSpec: ANY_TLS12
+channels:
+  song/released:
+    publish:
+      operationId: publish
+      message:
+        $ref: '#/components/messages/song'
+    subscribe:
+      operationId: subscribe
+      message:
+        $ref: '#/components/messages/song'
+components:
+  messages:
+    song:
+      payload:
+        type: object
+        properties:
+          title:
+            type: string
+            description: Song title
+          artist:
+            type: string
+            description: Song artist
+          album:
+            type: string
+            description: Song album
+          genre:
+            type: string
+            description: Primary song genre
+          length:
+            type: integer
+            description: Track length in seconds

--- a/src/examples/index.tsx
+++ b/src/examples/index.tsx
@@ -46,7 +46,7 @@ export default [
   },
   {
     title: 'MQTT',
-    description: () => <>A protocol for fetching resources. It is the foundation of any data exchange on the Web and it is a client-server protocol.</>,
+    description: () => <>An OASIS standard messaging protocol for the Internet of Things. Ideal for connecting remote devices with limited processing power and bandwidth.</>,
     template: mqtt,
     type: templateTypes.protocol
   },

--- a/src/examples/index.tsx
+++ b/src/examples/index.tsx
@@ -5,6 +5,7 @@ import kafka from './streetlights-kafka.yml';
 import websocket from './websocket-gemini.yml';
 import mqtt from './streetlights-mqtt.yml';
 import simple from './simple.yml';
+import ibmmq from './ibmmq.yml';
 
 // tutorial example
 import invalid from './tutorials/invalid.yml';
@@ -48,6 +49,12 @@ export default [
     title: 'MQTT',
     description: () => <>An OASIS standard messaging protocol for the Internet of Things. Ideal for connecting remote devices with limited processing power and bandwidth.</>,
     template: mqtt,
+    type: templateTypes.protocol
+  },
+  {
+    title: 'IBM MQ',
+    description: () => <>A robust, reliable, and secure messaging solution. IBM MQ simplifies and accelerates the integration of different applications across multiple platforms and supports a wide range of APIs and languages.</>,
+    template: ibmmq,
     type: templateTypes.protocol
   },
   {


### PR DESCRIPTION
**Description**
Adds a template for a basic IBM MQ specification to studio. This template is based on the example from our documentation.

I've also taken the opportunity to fix a typo and to update the MQTT template description as this was previously a copy of the HTTP description.