### PR TITLE
fix: update parser-js to v2

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -26,11 +26,11 @@
     "./LICENSE"
   ],
   "dependencies": {
-    "@asyncapi/avro-schema-parser": "^3.0.1",
+    "@asyncapi/avro-schema-parser": "^3.0.2",
     "@asyncapi/converter": "^1.2.0",
-    "@asyncapi/openapi-schema-parser": "^3.0.1",
-    "@asyncapi/parser": "^2.0.0-next-major.14",
-    "@asyncapi/react-component": "^1.0.0-next.47",
+    "@asyncapi/openapi-schema-parser": "^3.0.3",
+    "@asyncapi/parser": "^2.0.3",
+    "@asyncapi/react-component": "^1.0.0-next.48",
     "@asyncapi/specs": "^4.2.1",
     "@ebay/nice-modal-react": "^1.2.10",
     "@headlessui/react": "^1.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,11 +482,11 @@
       "version": "0.18.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/avro-schema-parser": "^3.0.1",
+        "@asyncapi/avro-schema-parser": "^3.0.2",
         "@asyncapi/converter": "^1.2.0",
-        "@asyncapi/openapi-schema-parser": "^3.0.1",
-        "@asyncapi/parser": "^2.0.0-next-major.14",
-        "@asyncapi/react-component": "^1.0.0-next.47",
+        "@asyncapi/openapi-schema-parser": "^3.0.3",
+        "@asyncapi/parser": "^2.0.3",
+        "@asyncapi/react-component": "^1.0.0-next.48",
         "@asyncapi/specs": "^4.2.1",
         "@ebay/nice-modal-react": "^1.2.10",
         "@headlessui/react": "^1.7.4",
@@ -558,19 +558,21 @@
       }
     },
     "apps/studio/node_modules/@asyncapi/avro-schema-parser": {
-      "version": "3.0.1",
-      "license": "Apache-2.0",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.2.tgz",
+      "integrity": "sha512-TZZedLaflgyYivwidJPqTN2LMk+Lqg0IByXtdzNYQZLNpLpcyEnXCxongoW0TVYgYGLWAghN3AmMOrrsVcGGOw==",
       "dependencies": {
-        "@asyncapi/parser": "^2.0.1",
+        "@asyncapi/parser": "^2.0.3",
         "@types/json-schema": "^7.0.11",
         "avsc": "^5.7.6"
       }
     },
     "apps/studio/node_modules/@asyncapi/openapi-schema-parser": {
-      "version": "3.0.1",
-      "license": "Apache-2.0",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.3.tgz",
+      "integrity": "sha512-R78pdOmkbWEnzYKAfx7PYUMJuR3hrReGJ0nfyUXs/nSz+yjH4kl2VHPmF2icKOpShdpv0nBkN0pup3w4D53FrQ==",
       "dependencies": {
-        "@asyncapi/parser": "^2.0.1",
+        "@asyncapi/parser": "^2.0.3",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -1560,6 +1562,15 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/@asyncapi/protobuf-schema-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-1.0.0.tgz",
+      "integrity": "sha512-eLfFhV6L+idW83LUspD6pzVwp2Zz0t3oW7kZD+USynmKZMkXnLmY7ON0q82Y5k0KZ34itoyyKu7YBYe4JxIZsw==",
+      "dependencies": {
+        "conventional-changelog-conventionalcommits": "^5.0.0",
+        "protocol-buffers-schema": "^3.6.0"
+      }
+    },
     "node_modules/@asyncapi/python-paho-template": {
       "version": "0.2.13",
       "dev": true,
@@ -1603,12 +1614,14 @@
       }
     },
     "node_modules/@asyncapi/react-component": {
-      "version": "1.0.0-next.47",
-      "license": "Apache-2.0",
+      "version": "1.0.0-next.48",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.48.tgz",
+      "integrity": "sha512-cF/tBMF7irQeImV5hqu8Ksm66ZY/+y5DsXpfLrOjTaZTVj90aR7Naj5OKIISg0jsW5modMAUAtAXO0agey8kig==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^1.1.0",
         "@asyncapi/openapi-schema-parser": "^2.0.1",
         "@asyncapi/parser": "^1.18.0",
+        "@asyncapi/protobuf-schema-parser": "^1.0.0",
         "highlight.js": "^10.7.2",
         "isomorphic-dompurify": "^0.13.0",
         "marked": "^4.0.14",
@@ -26568,6 +26581,11 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "dev": true,
@@ -38301,6 +38319,15 @@
         }
       }
     },
+    "@asyncapi/protobuf-schema-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-1.0.0.tgz",
+      "integrity": "sha512-eLfFhV6L+idW83LUspD6pzVwp2Zz0t3oW7kZD+USynmKZMkXnLmY7ON0q82Y5k0KZ34itoyyKu7YBYe4JxIZsw==",
+      "requires": {
+        "conventional-changelog-conventionalcommits": "^5.0.0",
+        "protocol-buffers-schema": "^3.6.0"
+      }
+    },
     "@asyncapi/python-paho-template": {
       "version": "0.2.13",
       "dev": true,
@@ -38340,11 +38367,14 @@
       }
     },
     "@asyncapi/react-component": {
-      "version": "1.0.0-next.47",
+      "version": "1.0.0-next.48",
+      "resolved": "https://registry.npmjs.org/@asyncapi/react-component/-/react-component-1.0.0-next.48.tgz",
+      "integrity": "sha512-cF/tBMF7irQeImV5hqu8Ksm66ZY/+y5DsXpfLrOjTaZTVj90aR7Naj5OKIISg0jsW5modMAUAtAXO0agey8kig==",
       "requires": {
         "@asyncapi/avro-schema-parser": "^1.1.0",
         "@asyncapi/openapi-schema-parser": "^2.0.1",
         "@asyncapi/parser": "^1.18.0",
+        "@asyncapi/protobuf-schema-parser": "^1.0.0",
         "highlight.js": "^10.7.2",
         "isomorphic-dompurify": "^0.13.0",
         "marked": "^4.0.14",
@@ -38409,7 +38439,7 @@
     "@asyncapi/studio": {
       "version": "file:apps/studio",
       "requires": {
-        "@asyncapi/avro-schema-parser": "^3.0.1",
+        "@asyncapi/avro-schema-parser": "^3.0.2",
         "@asyncapi/converter": "^1.2.0",
         "@asyncapi/dotnet-nats-template": "^0.11.0",
         "@asyncapi/go-watermill-template": "^0.2.34",
@@ -38420,10 +38450,10 @@
         "@asyncapi/markdown-template": "^1.2.1",
         "@asyncapi/nodejs-template": "^0.13.1",
         "@asyncapi/nodejs-ws-template": "^0.9.33",
-        "@asyncapi/openapi-schema-parser": "^3.0.1",
-        "@asyncapi/parser": "^2.0.0-next-major.14",
+        "@asyncapi/openapi-schema-parser": "^3.0.3",
+        "@asyncapi/parser": "^2.0.3",
         "@asyncapi/python-paho-template": "^0.2.13",
-        "@asyncapi/react-component": "^1.0.0-next.47",
+        "@asyncapi/react-component": "^1.0.0-next.48",
         "@asyncapi/specs": "^4.2.1",
         "@asyncapi/ts-nats-template": "^0.10.2",
         "@craco/craco": "^7.1.0",
@@ -38483,17 +38513,21 @@
       },
       "dependencies": {
         "@asyncapi/avro-schema-parser": {
-          "version": "3.0.1",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.2.tgz",
+          "integrity": "sha512-TZZedLaflgyYivwidJPqTN2LMk+Lqg0IByXtdzNYQZLNpLpcyEnXCxongoW0TVYgYGLWAghN3AmMOrrsVcGGOw==",
           "requires": {
-            "@asyncapi/parser": "^2.0.1",
+            "@asyncapi/parser": "^2.0.3",
             "@types/json-schema": "^7.0.11",
             "avsc": "^5.7.6"
           }
         },
         "@asyncapi/openapi-schema-parser": {
-          "version": "3.0.1",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.3.tgz",
+          "integrity": "sha512-R78pdOmkbWEnzYKAfx7PYUMJuR3hrReGJ0nfyUXs/nSz+yjH4kl2VHPmF2icKOpShdpv0nBkN0pup3w4D53FrQ==",
           "requires": {
-            "@asyncapi/parser": "^2.0.1",
+            "@asyncapi/parser": "^2.0.3",
             "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
             "ajv": "^8.11.0",
             "ajv-errors": "^3.0.0",
@@ -55144,6 +55178,11 @@
     "proto-list": {
       "version": "1.2.4",
       "dev": true
+    },
+    "protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "proxy-addr": {
       "version": "2.0.7",


### PR DESCRIPTION
Replaces https://github.com/asyncapi/studio/pull/572

**Description**

This PR updates **@asyncapi/parser** to v2 and uses the recently released custom schema parsers.

Note: this PR does not change Studio to start using the new Parser-API but keeps using the old wrapper `const oldDocument = convertToOldAPI(document);`.

**Related issue(s)**
https://github.com/asyncapi/parser-js/issues/585