### PR TITLE
fix: redirectFrom query parameter not leading to the opening of a Modal.

### DIFF
--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -12,7 +12,6 @@ export class ApplicationService extends AbstractService {
     this.hidePreloader();
 
     const { readOnly, url, base64, redirectedFrom } = this.svcs.navigationSvc.getUrlParameters();
-
     // readOnly state should be only set to true when someone pass also url or base64 parameter
     const isStrictReadonly = Boolean(readOnly && (url || base64));
 
@@ -33,7 +32,9 @@ export class ApplicationService extends AbstractService {
 
     // show RedirectedModal modal if the redirectedFrom is set (only when readOnly state is set to false)
     if (!isStrictReadonly && redirectedFrom) {
-      show(RedirectedModal);
+      setTimeout(() => {
+        show(RedirectedModal);
+      }, 500);
     }
   }
 

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -11,7 +11,7 @@ export class ApplicationService extends AbstractService {
     // subscribe to state to hide preloader
     this.hidePreloader();
 
-    const { readOnly, url, base64, redirectedFrom } = this.svcs.navigationSvc.getUrlParameters();
+    const { readOnly, url, base64 } = this.svcs.navigationSvc.getUrlParameters();
     // readOnly state should be only set to true when someone pass also url or base64 parameter
     const isStrictReadonly = Boolean(readOnly && (url || base64));
 
@@ -29,6 +29,11 @@ export class ApplicationService extends AbstractService {
         initialized: true,
       });
     }
+  }
+
+  public afterAppInit() {
+    const { readOnly, url, base64, redirectedFrom } = this.svcs.navigationSvc.getUrlParameters();
+    const isStrictReadonly = Boolean(readOnly && (url || base64));
 
     // show RedirectedModal modal if the redirectedFrom is set (only when readOnly state is set to false)
     if (!isStrictReadonly && redirectedFrom) {

--- a/src/services/app.service.ts
+++ b/src/services/app.service.ts
@@ -37,9 +37,7 @@ export class ApplicationService extends AbstractService {
 
     // show RedirectedModal modal if the redirectedFrom is set (only when readOnly state is set to false)
     if (!isStrictReadonly && redirectedFrom) {
-      setTimeout(() => {
-        show(RedirectedModal);
-      }, 500);
+      show(RedirectedModal);
     }
   }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- The error message clearly points that it doesn't find a parent `NiceModal.Provider`
```
Uncaught (in promise) Error: No dispatch method detected, did you embed your app with NiceModal.Provider?
    at m (index.tsx:104:9)
    at _ (index.tsx:225:3)
    at i.<anonymous> (app.service.ts:36:7)
    at f (regeneratorRuntime.js:44:17)
    at Generator.<anonymous> (regeneratorRuntime.js:125:22)
    at Generator.next (regeneratorRuntime.js:69:21)
    at r (asyncToGenerator.js:3:20)
    at s (asyncToGenerator.js:22:9)
```
- the issue was we were having the `show(RedirectModal)` in the `onInit` method, which was called in `createService` method in `/src/services/index.tsx` which was further called inside the `boostrap` method in the `/src/index.tsx`
     - reverse stack trace from [here](https://github.com/asyncapi/studio/blob/master/src/index.tsx#L37) :slightly_smiling_face: 
- at this point, the components are not rendered yet, therefore we are getting that error
- Moving the `show(RedirectModal)` logic to `afterAppInit` method in the `ApplicationService` solved the issue :smile: 

**Related issue(s)**
- Fixes #648 