### PR TITLE
chore: add Khuda as code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @fmvilas @boyney123 @mcturco @magicmatatjahu @asyncapi-bot-eve
+* @fmvilas @boyney123 @mcturco @magicmatatjahu @@KhudaDad414 @asyncapi-bot-eve

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @fmvilas @boyney123 @mcturco @magicmatatjahu @@KhudaDad414 @asyncapi-bot-eve
+* @fmvilas @boyney123 @mcturco @magicmatatjahu @KhudaDad414 @asyncapi-bot-eve


### PR DESCRIPTION
I'd love to invite @KhudaDad414 to become a code owner of this repo. Since the rest of the code owners are not very active lately and we want to move the project forward with the new Studio vision and plans: #634. He's already a TSC member so I figured he was the best candidate for now.