### PR TITLE
feat: update Parser-JS to v2.1.0-next-major-spec.5 so it really enables v3 validation

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -26,7 +26,7 @@
     "@asyncapi/avro-schema-parser": "^3.0.2",
     "@asyncapi/converter": "^1.3.1",
     "@asyncapi/openapi-schema-parser": "^3.0.4",
-    "@asyncapi/parser": "^2.1.0-next-major-spec.3",
+    "@asyncapi/parser": "^2.1.0-next-major-spec.5",
     "@asyncapi/react-component": "^1.0.0-next.48",
     "@asyncapi/specs": "^6.0.0-next-major-spec.6",
     "@ebay/nice-modal-react": "^1.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,13 +494,13 @@
     },
     "apps/studio": {
       "name": "@asyncapi/studio",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.2",
         "@asyncapi/converter": "^1.3.1",
         "@asyncapi/openapi-schema-parser": "^3.0.4",
-        "@asyncapi/parser": "^2.1.0-next-major-spec.3",
+        "@asyncapi/parser": "^2.1.0-next-major-spec.5",
         "@asyncapi/react-component": "^1.0.0-next.48",
         "@asyncapi/specs": "^6.0.0-next-major-spec.6",
         "@ebay/nice-modal-react": "^1.2.10",
@@ -653,8 +653,9 @@
       }
     },
     "apps/studio/node_modules/@asyncapi/parser": {
-      "version": "2.1.0-next-major-spec.3",
-      "license": "Apache-2.0",
+      "version": "2.1.0-next-major-spec.5",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0-next-major-spec.5.tgz",
+      "integrity": "sha512-j18xG8jKnIcgva9jWKJVCZNaPZhfPi8FBzKVeK9QTXxpm5tbq4wAuTWrTbEVDutc+fJgMdq3tMHlSricLanhHw==",
       "dependencies": {
         "@asyncapi/specs": "^6.0.0-next-major-spec.2",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
@@ -35190,7 +35191,7 @@
         "@asyncapi/nodejs-template": "^0.13.1",
         "@asyncapi/nodejs-ws-template": "^0.9.33",
         "@asyncapi/openapi-schema-parser": "^3.0.4",
-        "@asyncapi/parser": "^2.1.0-next-major-spec.3",
+        "@asyncapi/parser": "v2.1.0-next-major-spec.5",
         "@asyncapi/python-paho-template": "^0.2.13",
         "@asyncapi/react-component": "^1.0.0-next.48",
         "@asyncapi/specs": "^6.0.0-next-major-spec.6",
@@ -35330,7 +35331,9 @@
           }
         },
         "@asyncapi/parser": {
-          "version": "2.1.0-next-major-spec.3",
+          "version": "2.1.0-next-major-spec.5",
+          "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0-next-major-spec.5.tgz",
+          "integrity": "sha512-j18xG8jKnIcgva9jWKJVCZNaPZhfPi8FBzKVeK9QTXxpm5tbq4wAuTWrTbEVDutc+fJgMdq3tMHlSricLanhHw==",
           "requires": {
             "@asyncapi/specs": "^6.0.0-next-major-spec.2",
             "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",


### PR DESCRIPTION
**Description**

This PR updates the `@asyncapi/parser` package to the latest version of `next-major-spec` branch so it enables (really) the validation for AsyncAPI v3 documents.

cc @Amzani 