### PR TITLE
chore: Add Amzani as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @fmvilas @boyney123 @mcturco @magicmatatjahu @KhudaDad414 @asyncapi-bot-eve
+* @fmvilas @boyney123 @mcturco @magicmatatjahu @KhudaDad414 @Amzani @asyncapi-bot-eve


### PR DESCRIPTION
Hey Folks, I humbly suggest @Amzani as a code owner of this repo to support the new studio roadmap and mentor current contributors.

### Some contributions

- Driving the new studio enhancements as a product manager (e.g [issues](https://github.com/asyncapi/studio/issues?q=+is%3Aissue+project%3Aasyncapi%2F16+author%3AAmzani+) / [shapeIt dashboard](https://shapeit.app/projects/org/asyncapi/16/cycles/09a49498) / [planning meetings](https://www.youtube.com/watch?v=mAISwYCZa2I&ab_channel=AsyncAPI))
- Implementing [ShapeUp methodology](https://github.com/asyncapi/studio/issues/659) as a way to drive new studio enhancement 
- Added Architectural Decision Records (ADR) [process](https://github.com/asyncapi/studio/issues/663)
- Added [spec 3.0 validation support](https://github.com/asyncapi/studio/pull/747)
- Active participation during last months in the review process and engaging in issues ([insights](https://github.com/asyncapi/studio/pulse/monthly) / [2](https://github.com/asyncapi/studio/issues/822) / [3](https://github.com/asyncapi/studio/issues/809) / [4](https://github.com/asyncapi/studio/issues/728))
- Actively monitoring pending PR and unblocking CI (e.g [1](https://github.com/asyncapi/studio/pull/821) / [2](https://github.com/asyncapi/studio/issues/802))

If you notice something is still missing please feel free to give open an feedback
