### PR TITLE
fix: update old broken link to new one

### DIFF
--- a/apps/studio/src/examples/tutorials/invalid.yml
+++ b/apps/studio/src/examples/tutorials/invalid.yml
@@ -1,4 +1,4 @@
-# This invalid file exists solely for educational purposes, and if you come across it, here is the tutorial: https://www.asyncapi.com/docs/tutorials/validate-documents
+# This invalid file exists solely for educational purposes, and if you come across it, here is the tutorial: https://www.asyncapi.com/docs/tutorials/studio-document-validation
 
 asyncapi: '1.0.0'
 info:


### PR DESCRIPTION


**Description**

- Updated the old link to new one in the `Invalid Example` template in the `New file` section.

**Related issue(s)**

Fixes #834 