### PR TITLE
fix: update official invalid example to match tutorial

### DIFF
--- a/apps/studio/src/examples/tutorials/invalid.yml
+++ b/apps/studio/src/examples/tutorials/invalid.yml
@@ -1,22 +1,26 @@
 # This invalid file exists solely for educational purposes, and if you come across it, here is the tutorial: https://www.asyncapi.com/docs/tutorials/studio-document-validation
 
-asyncapi: '1.0.0'
+asyncapi: 3.0.0
 info:
   title: Streetlights API
   version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you
+    to remotely manage the city lights.
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
+
 servers:
   mosquitto:
-    url: mqtt://test.mosquitto.org
+    url: test.mosquitto.org
     protocol: mqtt
+
 channels:
-  light/measured:
-    publish:
-      summary: Inform about environmental lighting conditions for a particular streetlight.
-      operationId: onLightMeasured
-      message:
+  lightMeasured:
+    address: 'light/measured'
+    messages:
+      lightMeasuredMessage:
         name: LightMeasured
         payload:
           type: object
@@ -30,6 +34,13 @@ channels:
               minimum: 0
               description: Light intensity measured in lumens.
             sentAt:
-              type: integer
+              type: string
               format: date-time
               description: Date and time when the message was sent.
+
+operations:
+  onLightMeasured:
+    action: 'receive'
+    summary: Inform about environmental lighting conditions for a particular streetlight.
+    channel:
+      $ref: '#/channels/lightMeasured'


### PR DESCRIPTION
making sure invalid example match the one mentioned in tutorial 

https://v3.asyncapi.com/docs/tutorials/studio-document-validation

marked as `fix` as I kinda assume it will be automatically released once I do it