### PR TITLE
chore: add princerajpoot20 as code owner for ds and ui

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,6 @@
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
 * @fmvilas @boyney123 @mcturco @magicmatatjahu @KhudaDad414 @Amzani @asyncapi-bot-eve
+
+apps/design-system/ @fmvilas @mcturco @KhudaDad414 @Amzani @princerajpoot20
+packages/ui/ @fmvilas @mcturco @KhudaDad414 @Amzani @princerajpoot20


### PR DESCRIPTION
I suggest @princerajpoot20 as a code owner for the design system `apps/design-system/` and ui `packages/ui/` as he did major contribution to build the new components, and he is committed to support new studio vision and plans #634.

### Some contributions
- https://github.com/asyncapi/studio/pull/708
- https://github.com/asyncapi/studio/pull/710
- https://github.com/asyncapi/studio/pull/711
- https://github.com/asyncapi/studio/pull/718
- https://github.com/asyncapi/studio/pull/792
- https://github.com/asyncapi/studio/pull/808

In addition to committing to this repos he is also reviewing the work of others (e.g https://github.com/asyncapi/studio/pull/784 / https://github.com/asyncapi/studio/pull/773)
