### PR TITLE
chore: removing myself as maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
-* @fmvilas @boyney123 @mcturco @magicmatatjahu @KhudaDad414 @Amzani @asyncapi-bot-eve
+* @magicmatatjahu @KhudaDad414 @Amzani @asyncapi-bot-eve
 
-apps/design-system/ @fmvilas @mcturco @KhudaDad414 @Amzani @princerajpoot20
-packages/ui/ @fmvilas @mcturco @KhudaDad414 @Amzani @princerajpoot20
+apps/design-system/ @KhudaDad414 @Amzani @princerajpoot20
+packages/ui/ @KhudaDad414 @Amzani @princerajpoot20


### PR DESCRIPTION
**Description**
I'm removing myself as a code owner. I don't really have time to review or write code anymore. However, I'll still be participating in some discussions. The repo is now on good hands so no need to keep myself here.

I'm also taking the opportunity to remove @boyney123 and @mcturco as they haven't been active in the repo for more than a year now so I think it's safe to say they're not maintainers either. Challenge this decision if you think I'm wrong, of course. Happy to revert it if needed.
