### PR TITLE
Fixed Issue #1100 about Github link 

### DIFF
--- a/apps/studio/src/components/Toolbar.tsx
+++ b/apps/studio/src/components/Toolbar.tsx
@@ -27,7 +27,7 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = () => {
               </a>
             </li>
             <li className="text-xl ml-2 opacity-75 hover:opacity-100">
-              <a href='https://github.com/asyncapi' title='AsyncAPI Github Organization' target='_blank' rel="noreferrer">
+              <a href='https://github.com/asyncapi/studio' title='AsyncAPI Studio Github Repository' target='_blank' rel="noreferrer">
                 <IoLogoGithub />
               </a>
             </li>


### PR DESCRIPTION
- Github icon in the toolbar rightly redirects to Asyncapi Studio Repo. 
- Updated url as well as title.
