### PR TITLE
fix(cold-start): add another component as layer for lazy loading

### DIFF
--- a/apps/studio-next/src/app/page.tsx
+++ b/apps/studio-next/src/app/page.tsx
@@ -1,7 +1,6 @@
-import dynamic from 'next/dynamic';
-const StudioWrapper = dynamic(() => import('@/components/StudioWrapper'), {ssr: false})
 import { Metadata } from 'next';
 import ogImage from '@/img/meta-studio-og-image.jpeg';
+import StudioEditor from '@/components/StudioEditor';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://studio-next.netlify.app'),
@@ -25,6 +24,6 @@ export const metadata: Metadata = {
 }
 export default async function Home() {
   return (
-    <StudioWrapper />
+    <StudioEditor />
   )
 }

--- a/apps/studio-next/src/components/StudioEditor.tsx
+++ b/apps/studio-next/src/components/StudioEditor.tsx
@@ -1,0 +1,10 @@
+'use client'
+import dynamic from 'next/dynamic'
+const StudioWrapper = dynamic(() => import('@/components/StudioWrapper'), {ssr: false})
+
+
+export default async function StudioEditor() {
+  return (
+    <StudioWrapper />
+  )
+}


### PR DESCRIPTION
Using `next/dynamic` in server components that loading a client component is still including everything in server side rendering, and that client component doesn't know it needs to be split into another chunk in browser chunks.

Related: https://github.com/vercel/next.js/issues/49454#issuecomment-1830053413

**Description**
I set up my own deployment here https://jolly-toffee-18b732.netlify.app and tested the results below
![Screenshot 2024-07-05 145715](https://github.com/asyncapi/studio/assets/54782057/c306278b-3e93-47c8-b70f-32c4331c6df1)


**Related issue(s)**
Fixes #1118 