### PR TITLE
changed-urls-and-defaultport

### DIFF
--- a/apps/studio/cypress.config.ts
+++ b/apps/studio/cypress.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:3001',
+    baseUrl: 'http://localhost:3000',
     retries: {
       runMode: 1,
       openMode: 1,

--- a/apps/studio/src/services/server-api.service.ts
+++ b/apps/studio/src/services/server-api.service.ts
@@ -12,7 +12,7 @@ export interface ServerAPIProblem {
 }
 
 export class ServerAPIService extends AbstractService {
-  private serverPath = 'http://localhost:3001/api/v1';
+  private serverPath = 'https://api.asyncapi.com/v1';
 
   async generate(data: {
     asyncapi: string | Record<string, any>,


### PR DESCRIPTION

**Description**
1. When `studio-next` was migrated into `studio` the port was changed from `3001` to `3000`.
Hence changing the cypress e2e baseUrl to `3000`
2. Changed hardcoded `serverPath` to the real api url. It was made hardcoded in this [commit](https://github.com/asyncapi/studio/commit/41365d42b8b0a7bee4197e966b5cc900875937b8#diff-7911c8d6c958d8d261602e2b153659dce570f122db8dc077ad1ed95912edd461). 
This is related to the issue #1144 
 


**Related issue(s)**
#1144 