### PR TITLE
fix(studio): fix Docker build

### DIFF
--- a/.changeset/sour-waves-visit.md
+++ b/.changeset/sour-waves-visit.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/studio": patch
+---
+
+Fix Docker build for AsyncAPI Studio

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ pnpm run dev
 pnpm run build:studio
 ```
 
+#### Build Studio for Docker
+
+```
+docker build -f apps/studio/Dockerfile -t asyncapi/studio .
+```
+For instructions on running it please refer to this [doc](/apps/studio/README.md#using-it-via-docker).
+
 #### Build the Design System for production
 
 ```

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache libc6-compat
 RUN apk update
 # Set working directory
 WORKDIR /app
-RUN npm install --global turbo
+RUN npm install --global turbo@1
 COPY . .
 RUN turbo prune --scope=@asyncapi/studio --docker
  
@@ -21,17 +21,17 @@ ARG BASE_URL_PLACEHOLDER
 RUN apk add --no-cache libc6-compat
 RUN apk update
 WORKDIR /app
- 
+RUN npm install --global pnpm@latest-10
+
 # First install the dependencies (as they change less often)
 
 COPY .gitignore .gitignore
 COPY --from=builder /app/out/json/ .
-COPY --from=builder /app/out/package-lock.json ./package-lock.json
-RUN PUPPETEER_SKIP_DOWNLOAD=true npm ci
- 
+RUN PUPPETEER_SKIP_DOWNLOAD=true pnpm install
+
 # Build the project
 COPY --from=builder /app/out/full/ .
-RUN PUBLIC_URL=${BASE_URL_PLACEHOLDER} npm run build:studio
+RUN PUBLIC_URL=${BASE_URL_PLACEHOLDER} NEXT_CONFIG_OUTPUT=export pnpm run build:studio
  
 
 FROM docker.io/library/nginx:1.25.5-alpine as runtime

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=builder /app/out/full/ .
 RUN PUBLIC_URL=${BASE_URL_PLACEHOLDER} NEXT_CONFIG_OUTPUT=export pnpm run build:studio
  
 
-FROM docker.io/library/nginx:1.25.5-alpine as runtime
+FROM docker.io/library/nginx:1.25.5-alpine AS runtime
 
 ARG BASE_URL_PLACEHOLDER
 # The base Nginx image automatically executes all shell scripts 

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -36,7 +36,7 @@ const nextConfig = {
 
     return config;
   },
-  output: 'standalone',
+  output: process.env.NEXT_CONFIG_OUTPUT ?? 'standalone',
   distDir: 'build'
 };
 

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -28,7 +28,8 @@
         "./src/*",
         "./public/*"
       ]
-    }
+    },
+    "types": ["cypress"]
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
**Description**

The Docker publish workflow has been broken since the migration to Next.js and/or PNPM, see https://github.com/asyncapi/studio/actions/workflows/publish-docker-image.yml.

This MR adapts the Dockerfile to be compatible with the new setup.

**Related issue(s)**

Discovered while trying to validate https://github.com/asyncapi/studio/pull/1150

⚒️ with ❤️ by [Siemens](https://opensource.siemens.com/)