### PR TITLE
feat: additional changes for implementation of new preview command

### DIFF
--- a/.changeset/honest-candles-brush.md
+++ b/.changeset/honest-candles-brush.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/studio": patch
+---
+
+feat: additional changes for implementation of new preview command

--- a/apps/studio/src/components/Modals/ConvertToLatestModal.tsx
+++ b/apps/studio/src/components/Modals/ConvertToLatestModal.tsx
@@ -5,7 +5,7 @@ import { create } from '@ebay/nice-modal-react';
 import { ConfirmModal } from './ConfirmModal';
 
 import { useServices } from '../../services';
-import { useDocumentsState } from '../../state';
+import { useDocumentsState,appState } from '../../state';
 
 interface ConvertToLatestModal {
   convertOnlyToLatest: boolean
@@ -57,55 +57,57 @@ export const ConvertToLatestModal = create<ConvertToLatestModal>(({ convertOnlyT
     content = 'There is a new version of AsyncAPI. Convert your document to newest version if you want.';
   }
 
-  return (
-    <ConfirmModal
-      title={convertOnlyToLatest ? 'Convert AsyncAPI document to latest version' : 'Convert AsyncAPI document to newest version'}
-      confirmText={convertOnlyToLatest ? `Convert to ${latestVersion}` : 'Convert'}
-      confirmDisabled={false}
-      onSubmit={onSubmit}
-    >
-      <div className="flex flex-col content-center justify-center text-center">
-        <p>
-          {content}
-        </p>
-        <ul className="mt-4">
-          {reservedAllowedVersions.map(v => v !== '2.0.0' && (
-            <li key={v}>
-              <a
-                className="underline"
-                href={`https://www.asyncapi.com/blog/release-notes-${v}`}
-                target="_blank"
-                rel="nofollow noopener noreferrer"
+  if (!appState.getState().readOnly) {
+    return (
+      <ConfirmModal
+        title={convertOnlyToLatest ? 'Convert AsyncAPI document to latest version' : 'Convert AsyncAPI document to newest version'}
+        confirmText={convertOnlyToLatest ? `Convert to ${latestVersion}` : 'Convert'}
+        confirmDisabled={false}
+        onSubmit={onSubmit}
+      >
+        <div className="flex flex-col content-center justify-center text-center">
+          <p>
+            {content}
+          </p>
+          <ul className="mt-4">
+            {reservedAllowedVersions.map(v => v !== '2.0.0' && (
+              <li key={v}>
+                <a
+                  className="underline"
+                  href={`https://www.asyncapi.com/blog/release-notes-${v}`}
+                  target="_blank"
+                  rel="nofollow noopener noreferrer"
+                >
+                  See the release notes for {v}
+                </a>
+              </li>
+            ))}
+          </ul>
+          {convertOnlyToLatest === false ? (
+            <div className="flex content-center justify-center mt-4">
+              <label
+                htmlFor="asyncapi-version"
+                className="flex justify-right items-center w-1/2 content-center font-medium text-gray-700"
               >
-                See the release notes for {v}
-              </a>
-            </li>
-          ))}
-        </ul>
-        {convertOnlyToLatest === false ? (
-          <div className="flex content-center justify-center mt-4">
-            <label
-              htmlFor="asyncapi-version"
-              className="flex justify-right items-center w-1/2 content-center font-medium text-gray-700"
-            >
-              To version:
-            </label>
-            <select
-              name="asyncapi-version"
-              className="shadow-sm focus:ring-pink-500 focus:border-pink-500 w-1/2 block w-full sm:text-sm border-gray-300 rounded-md py-2 px-1 text-gray-700 border-pink-300 border-2"
-              onChange={e => setVersion(e.target.value)}
-              value={version}
-            >
-              <option value={latestVersion} key={latestVersion}>{latestVersion} (latest)</option>
-              {reservedAllowedVersions.filter((v) => v !== latestVersion).map(v => (
-                <option key={v} value={v}>
-                  {v}
-                </option>
-              ))}
-            </select>
-          </div>
-        ) : null}
-      </div>
-    </ConfirmModal>
-  );
+                To version:
+              </label>
+              <select
+                name="asyncapi-version"
+                className="shadow-sm focus:ring-pink-500 focus:border-pink-500 w-1/2 block w-full sm:text-sm border-gray-300 rounded-md py-2 px-1 text-gray-700 border-pink-300 border-2"
+                onChange={e => setVersion(e.target.value)}
+                value={version}
+              >
+                <option value={latestVersion} key={latestVersion}>{latestVersion} (latest)</option>
+                {reservedAllowedVersions.filter((v) => v !== latestVersion).map(v => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+        </div>
+      </ConfirmModal>
+    );
+  }
 });

--- a/apps/studio/src/services/index.ts
+++ b/apps/studio/src/services/index.ts
@@ -13,9 +13,11 @@ import { ServerAPIService } from './server-api.service';
 import { SettingsService } from './settings.service';
 import { SocketClient } from './socket-client.service';
 import { SpecificationService } from './specification.service';
+import { PreviewSockeClient } from './preview.service';
 
 export type Services = {
   appSvc: ApplicationService;
+  previewSvc: PreviewSockeClient;
   converterSvc: ConverterService;
   editorSvc: EditorService;
   formatSvc: FormatService;
@@ -41,6 +43,7 @@ export async function createServices() {
 
   services.parserSvc = new ParserService(services);
   services.appSvc = new ApplicationService(services);
+  services.previewSvc = new PreviewSockeClient(services);
   services.converterSvc = new ConverterService(services);
   services.editorSvc = new EditorService(services);
   services.formatSvc = new FormatService(services);

--- a/apps/studio/src/services/navigation.service.ts
+++ b/apps/studio/src/services/navigation.service.ts
@@ -20,6 +20,7 @@ export class NavigationService extends AbstractService {
       share: urlParams.get('share'),
       readOnly: urlParams.get('readOnly') === 'true' || urlParams.get('readOnly') === '',
       liveServer: urlParams.get('liveServer'),
+      previewServer: urlParams.get('previewServer'),
       redirectedFrom: urlParams.get('redirectedFrom'),
     };
   }

--- a/apps/studio/src/services/preview.service.tsx
+++ b/apps/studio/src/services/preview.service.tsx
@@ -1,0 +1,104 @@
+import { appState } from '@/state';
+import { AbstractService } from './abstract.service';
+import toast from 'react-hot-toast';
+
+interface IncomingMessage {
+    type: 'preview:file:added' | 'preview:file:changed' | 'preview:file:deleted' | 'preview:connected';
+    code?: string
+}
+
+export class PreviewSockeClient extends AbstractService {
+  private ws: WebSocket | null = null;
+  private isVerified = false;
+
+  public override onInit(): void {
+    // return if the readOnly state is already set by the application service by presence of url and readOnly parameter
+    if (appState.getState().readOnly) {
+      return
+    }
+    this.disconnect();
+    const {previewServer} = this.svcs.navigationSvc.getUrlParameters();
+
+    const previewServerPort = previewServer && Number(previewServer);
+
+    if (previewServer && previewServerPort) {
+      try {
+        this.ws = new WebSocket(`ws://${'localhost'}:${previewServerPort}/preview-server`);
+        this.ws.onopen = this.onOpen.bind(this);
+        this.ws.onerror = this.onError.bind(this);
+        this.ws.onmessage = this.handleMessage.bind(this);
+      } catch (e) {
+        console.log(e)
+        this.onError();
+      }
+    }
+  }
+
+  private handleMessage(event: MessageEvent<any>) {
+    try {
+      const message: IncomingMessage = JSON.parse(event.data);
+      if (!this.isVerified) {
+        if (message.type === 'preview:connected') {
+          this.isVerified = true;
+          appState.setState({
+            readOnly: true,
+            initialized: true,
+          });
+          return;
+        } 
+        console.error('Received unexpected message before verification:', message);
+        this.disconnect();
+        return;
+      }
+      // after verification handling rest of the messages
+      switch (message.type) {
+      case 'preview:file:added':
+      case 'preview:file:changed':
+        this.svcs.editorSvc.updateState({ 
+          content: message.code as string, 
+          updateModel: true, 
+          sendToServer: false,
+        });
+        break;  
+      case 'preview:file:deleted':
+        console.warn('Preview Server: The file has been deleted on the file system.');
+        break;
+      default:
+        console.warn('Live Server: An unknown even has been received. See details in console');
+        console.error(message);
+        break;
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
+  disconnect() {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.isVerified =false;
+  }
+
+  private onOpen() {
+    toast.success(
+      <div>
+        <span className="block text-bold">
+          Correctly connected to the preview server!
+        </span>
+      </div>
+    );
+    appState.setState({ liveServer: true });
+  }
+
+  private onError() {
+    toast.error(
+      <div>
+        <span className="block text-bold">
+          Failed to connect to preview server. Please check developer console for more information.
+        </span>
+      </div>
+    );
+    appState.setState({ liveServer: false });
+  }
+}

--- a/apps/studio/src/services/socket-client.service.tsx
+++ b/apps/studio/src/services/socket-client.service.tsx
@@ -5,7 +5,7 @@ import toast from 'react-hot-toast';
 import { appState } from '@/state';
 
 interface IncomingMessage {
-  type: 'file:loaded' | 'file:changed' | 'file:deleted' | 'mode:preview';
+  type: 'file:loaded' | 'file:changed' | 'file:deleted';
   code?: string;
 }
 
@@ -13,9 +13,9 @@ export class SocketClient extends AbstractService {
   private ws!: WebSocket;
 
   public override onInit(): void {
-    const { url, base64, readOnly, liveServer } = this.svcs.navigationSvc.getUrlParameters();
+    const { url, base64, readOnly, liveServer, previewServer } = this.svcs.navigationSvc.getUrlParameters();
 
-    const shouldConnect = !(base64 || url || readOnly);
+    const shouldConnect = !(base64 || url || readOnly || previewServer);
     if (!shouldConnect) {
       return;
     }
@@ -58,12 +58,6 @@ export class SocketClient extends AbstractService {
         break;
       case 'file:deleted':
         console.warn('Live Server: The file has been deleted on the file system.');
-        break;
-      case 'mode:preview':
-        appState.setState({
-          readOnly: true,
-          initialized: true,
-        });  
         break;
       default:
         console.warn('Live Server: An unknown even has been received. See details:');

--- a/apps/studio/src/services/socket-client.service.tsx
+++ b/apps/studio/src/services/socket-client.service.tsx
@@ -5,7 +5,7 @@ import toast from 'react-hot-toast';
 import { appState } from '@/state';
 
 interface IncomingMessage {
-  type: 'file:loaded' | 'file:changed' | 'file:deleted';
+  type: 'file:loaded' | 'file:changed' | 'file:deleted' | 'mode:preview';
   code?: string;
 }
 
@@ -58,6 +58,12 @@ export class SocketClient extends AbstractService {
         break;
       case 'file:deleted':
         console.warn('Live Server: The file has been deleted on the file system.');
+        break;
+      case 'mode:preview':
+        appState.setState({
+          readOnly: true,
+          initialized: true,
+        });  
         break;
       default:
         console.warn('Live Server: An unknown even has been received. See details:');


### PR DESCRIPTION
**Description**

This PR introduces the necessary changes for the implementation of  `readOnly` mode in studio when used with `asyncapi start preview` command.

Requirments:-

As the requirements of the implementation of this are following:-

- Starting of studio in it's minimal state when done through the to be implemented command `asyncapi start preview`.
- Other elements are disabled in this.
- Additon of websocket for syncing the  changes that come form file but not allowed to change anything from studio side.

These are also mentioned here https://github.com/asyncapi/cli/issues/1627#issuecomment-2730869866.

 Approach:-

To achieve the above requirements I tried a few different approaches as below :-

1. As current implementation of readOnly requires the file to be served in from either URL or base64 so one approach can be to start a mini file server and server the file from same. This approach is problematic as first starting the file server will consume more memory and second being that syncig through websocket will be problematic. Hence this was discarded.
2. One more approach can be to use current `start studio` command to set the readOnly state but this is also not feasible as first this will alter the current `start studio` command functionality and also disabling the editing will be challenging.

Now comes the approach which this PR presents. This PR introduces a new service for handling the `start preview` command. When studio is started through this first form the cli a confirmation message is sent before any message that this instance of studio was started with the `start preview` command and then only set the readOnly state in the studio. This verification ensures that the readOnly can only be set from this command or either from the other `url` approach. A check is also there to prevent this form setting the readOnly state again if it is already set through the presence of `url` and `readOnly` in the URL parameters which ensures that the normal behaviour is not affected. 

Also the pop up dialog that asks to change schema if the loaded schema is old one(like version 2.x or 1.x) as the state is readOnly so allowing changes is bit counter intuitive. 


**Related issue(s)**

Resolves #1166 