### PR TITLE
feat: implement changes for readonly parameter

### DIFF
--- a/apps/studio/src/components/Sidebar.tsx
+++ b/apps/studio/src/components/Sidebar.tsx
@@ -60,7 +60,12 @@ export const Sidebar: FunctionComponent<SidebarProps> = () => {
   ]) || [null, false];
 
   const [isV3, setIsV3] = useState(document?.version().startsWith('3.'));
+  const [isReadOnly, setIsReadOnly] = useState(false);
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setIsReadOnly(params.get('readOnly') === 'true');
+  }, []);
   let navigation: NavItem[] = [
     // navigation
     {
@@ -73,28 +78,31 @@ export const Sidebar: FunctionComponent<SidebarProps> = () => {
       enabled: true,
       dataTest: 'button-navigation',
     },
-    // editor
-    {
-      name: 'primaryPanel',
-      title: 'Editor',
-      isActive: show.primaryPanel,
-      onClick: () => updateState('primaryPanel'),
-      icon: <VscCode className="w-5 h-5" />,
-      tooltip: 'Editor',
-      enabled: true,
-      dataTest: 'button-editor',
-    },
-    // template
-    {
-      name: 'template',
-      title: 'Template preview',
-      isActive: show.secondaryPanel && secondaryPanelType === 'template',
-      onClick: () => updateState('secondaryPanel', 'template'),
-      icon: <VscOpenPreview className="w-5 h-5" />,
-      tooltip: 'Template preview',
-      enabled: true,
-      dataTest: 'button-template-preview',
-    },
+    
+    ...(!isReadOnly ? [
+      // editor
+      {
+        name: 'primaryPanel',
+        title: 'Editor',
+        isActive: show.primaryPanel,
+        onClick: () => updateState('primaryPanel'),
+        icon: <VscCode className="w-5 h-5" />,
+        tooltip: 'Editor',
+        enabled: true,
+        dataTest: 'button-editor',
+      },
+      // template
+      {
+        name: 'template',
+        title: 'Template preview',
+        isActive: show.secondaryPanel && secondaryPanelType === 'template',
+        onClick: () => updateState('secondaryPanel', 'template'),
+        icon: <VscOpenPreview className="w-5 h-5" />,
+        tooltip: 'Template preview',
+        enabled: true,
+        dataTest: 'button-template-preview',
+      }] : []),
+
     // visuliser
     {
       name: 'visualiser',

--- a/apps/studio/src/components/SplitPane/SplitPane.tsx
+++ b/apps/studio/src/components/SplitPane/SplitPane.tsx
@@ -70,7 +70,8 @@ function SplitPane(props) {
   const [pane2Size, setPane2Size] = useState(primary === 'second' ? initialSize : undefined);
   const [draggedSize, setDraggedSize] = useState();
   const [position, setPosition] = useState();
-
+  const [isReadOnly, setIsReadOnly] = useState(false);
+  
   const splitPane = useRef();
   const pane1 = useRef();
   const pane2 = useRef();
@@ -219,6 +220,9 @@ function SplitPane(props) {
 
     getSizeUpdate();
 
+    const params = new URLSearchParams(window.location.search);
+    setIsReadOnly(params.get('readOnly') === 'true');
+
     return () => {
       document.removeEventListener('mouseup', onMouseUp);
       document.removeEventListener('mousemove', onMouseMove);
@@ -280,29 +284,33 @@ function SplitPane(props) {
       style={style}
     >
       <Pane
-        className={pane1Classes}
-        key="pane1"
-        eleRef={node => {
-          pane1.current = node;
-        }}
-        size={pane1Size}
-        split={split}
-        style={pane1Style}
-      >
-        {notNullChildren[0]}
+          className={pane1Classes}
+          key="pane1"
+          eleRef={node => {
+            pane1.current = node;
+          }}
+          size={isReadOnly ? 0 : pane1Size}
+          split={split}
+          style={pane1Style}
+        >
+          {notNullChildren[0]}
       </Pane>
-      <Resizer
-        className={disabledClass}
-        onClick={onResizerClick}
-        onDoubleClick={onResizerDoubleClick}
-        onMouseDown={onMouseDown}
-        onTouchStart={onTouchStart}
-        onTouchEnd={onMouseUp}
-        key="resizer"
-        resizerClassName={resizerClassNamesIncludingDefault}
-        split={split}
-        style={resizerStyle || {}}
-      />
+        
+      {!isReadOnly && (
+        <Resizer
+          className={disabledClass}
+          onClick={onResizerClick}
+          onDoubleClick={onResizerDoubleClick}
+          onMouseDown={onMouseDown}
+          onTouchStart={onTouchStart}
+          onTouchEnd={onMouseUp}
+          key="resizer"
+          resizerClassName={resizerClassNamesIncludingDefault}
+          split={split}
+          style={resizerStyle || {}}
+        />
+      )}
+      
       <Pane
         className={pane2Classes}
         key="pane2"


### PR DESCRIPTION
### **Related issue(s)**
#1166

### **Description**
This PR adds support for the read-only mode in Studio when using the `asyncapi start preview` command.

### **Approach**
If the URL contains `readonly=true`, the `Editor` and `Template Preview` buttons in the sidebar will be hidden, along with the `primaryPanel` (which contains the editor).

@Shurtu-gal Please review my PR.