### PR TITLE
fix: build cache ignored for smaller bundle size

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -15,13 +15,30 @@
   "author": {
     "name": "The AsyncAPI maintainers"
   },
-  "files": [
-    "/build",
-    "/public",
-    "./README.md",
-    "./LICENSE",
-    "./next.config.js"
-  ],
+ "files": [
+  "/build/server",
+  "/build/standalone",
+  "/build/static",
+  "/build/types",
+  "/build/app-build-manifest.json",
+  "/build/app-path-routes-manifest.json",
+  "/build/BUILD_ID",
+  "/build/build-manifest.json",
+  "/build/export-marker.json",
+  "/build/images-manifest.json",
+  "/build/next-minimal-server.js.nft.json",
+  "/build/next-server.js.nft.json",
+  "/build/package.json",
+  "/build/prerender-manifest.json",
+  "/build/react-loadable-manifest.json",
+  "/build/required-server-files.json",
+  "/build/routes-manifest.json",
+  "/build/trace",
+  "/public",
+  "./README.md",
+  "./LICENSE",
+  "./next.config.js"
+],
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
**Description**

This pull request introduces the changes to update the `files` field in the `apps/studio/package.json` file to include only the necessary files and not the `cache` files in order to reduce the package size and bundle size.

Resolves #1193 

### Changes to `files` field in `package.json`:
* Replaced the single entry `/build` with a comprehensive list of specific build files and subdirectories, such as `/build/server`, `/build/standalone`, and `/build/static`, among others. This provides finer-grained control over the included build artifacts.

Screenshots of package size taken up in `cli` by `studio`  after removing cache files.

![Screenshot From 2025-05-24 21-12-26](https://github.com/user-attachments/assets/c3c00324-0a4b-4579-a40a-d0628fdb4ff9)
![Screenshot From 2025-05-24 21-12-43](https://github.com/user-attachments/assets/ff741fda-8be2-45f9-87f6-fc3067d9d2d2)
![Screenshot From 2025-05-24 21-12-55](https://github.com/user-attachments/assets/02620856-fb0d-4aaa-87ca-76c428dc7c8b)
![Screenshot From 2025-05-24 21-13-01](https://github.com/user-attachments/assets/12c36ca8-5182-4a83-a8bb-c24a6fa8c6b2)
![Screenshot From 2025-05-24 21-13-14](https://github.com/user-attachments/assets/164b9b28-2dc2-42ee-b67f-4879e558da04)
