### PR TITLE
fix: support BASE_URL for studio docker builds

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -43,7 +43,7 @@ ARG BASE_URL_PLACEHOLDER
 # https://github.com/nginxinc/docker-nginx/blob/master/entrypoint/docker-entrypoint.sh#L16.
 ARG ENTRYPOINT_SCRIPT=/docker-entrypoint.d/set-public-url.sh
 
-COPY --from=installer /app/apps/studio/build /usr/share/nginx/html/
+COPY --from=installer --chown=nginx:nginx /app/apps/studio/build /usr/share/nginx/html/
 # Add an entrypoint script that replaces all occurrences of the 
 # placeholder value by the configured base URL. If no base URL
 # is configured we assume the application is running at '/'.

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -1,5 +1,5 @@
 # Use a UUID as placeholder value to have a unique string to replace. 
-ARG BASE_URL_PLACEHOLDER=189b303e-37a0-4f6f-8c0a-50333bc3c36e
+ARG BASE_URL_PLACEHOLDER=/189b303e-37a0-4f6f-8c0a-50333bc3c36e
 
 
 FROM node:18-alpine AS base

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -36,6 +36,7 @@ const nextConfig = {
 
     return config;
   },
+  basePath: process.env.PUBLIC_URL ?? '',
   output: process.env.NEXT_CONFIG_OUTPUT ?? 'standalone',
   distDir: 'build'
 };

--- a/apps/studio/src/app/page.tsx
+++ b/apps/studio/src/app/page.tsx
@@ -34,8 +34,8 @@ export const metadata : Metadata = {
     images: ['/img/meta-studio-og-image.jpeg'],
   },
   icons: {
-    icon: '/favicon.ico',
-    apple: '/favicon-194x194.png',
+    icon: `${process.env.PUBLIC_URL ?? ''}/favicon.ico`,
+    apple: `${process.env.PUBLIC_URL ?? ''}/favicon-194x194.png`,
   },
 };
 


### PR DESCRIPTION
**Description**

The support for the `BASE_URL` environment variable introduced within https://github.com/asyncapi/studio/pull/248 was sadly broken when the project migrated to Next.JS.

This PR is composed of two commits:
1. The first commit fixes the permissions when copying the static assets for the Docker image (in particular, the `logo-studio.svg` was not loading, even when running without a `BASE_URL` - see below)
2. The second commit adds the `basePath` Next.JS config option as documented within [the official doc](https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath).

**Related issue(s)**

Related to https://github.com/asyncapi/studio/issues/249

**logo-studio.svg not loading due to nginx file permissions**

![Screenshot from 2025-06-19 14-53-24](https://github.com/user-attachments/assets/dbc0898c-3730-4119-931f-d9273e8fe5b9)

**PR test**

I built locally the image and deployed it on our k8s environment with `BASE_URL=/tools/asyncapi-studio` 

![Unsaved Image 1](https://github.com/user-attachments/assets/ca4cb7bc-9f4e-4ef6-9d79-c5d1f36b0789)


/cc @fgreinacher 

🛠️ with ❤️ by [Siemens](https://opensource.siemens.com/)