### PR TITLE
fix: Excluded templates that dont support asyncapi 3.0.0

### DIFF
--- a/apps/studio/src/components/Modals/Generator/GeneratorModal.tsx
+++ b/apps/studio/src/components/Modals/Generator/GeneratorModal.tsx
@@ -23,6 +23,9 @@ const unsupportedGenerators = [
   '@asyncapi/php-template',
   '@asyncapi/python-paho-template',
   '@asyncapi/ts-nats-template',
+  '@asyncapi/html-template',
+  '@asyncapi/java-template',
+  '@asyncapi/markdown-template',
 ];
 
 const renderOptions = (actualVersion: string) => {


### PR DESCRIPTION
**Description**

- The generator does not support doc version 3.0.0 for these templates, as we get an error message when trying to generate the same
- Its better to disable these options from menu until we have support 
- This will reduce issues raised by users or any misconception.

Resolves #1192 