### PR TITLE
fix: rename subcribeToDocuments to subscribeToDocuments

### DIFF
--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -21,7 +21,7 @@
     "generate:assets": "echo \"No assets to configure\"",
     "test": "echo \"No tests\"",
     "eject": "react-scripts eject",
-    "dev": "concurrently 'npm run watch:*'",
+    "dev": "concurrently 'pnpm run watch:*'",
     "watch:storybook": "storybook dev -p 6006 --no-open",
     "watch:tailwind": "npx tailwindcss -i ./src/styles/tailwind.css -o ./src/styles/tailwind.output.css --watch",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/apps/studio/src/services/editor.service.tsx
+++ b/apps/studio/src/services/editor.service.tsx
@@ -365,6 +365,7 @@ export class EditorService extends AbstractService {
     return { decorations: newDecorations, markers: newMarkers };
   }
 
+  /* eslint-disable indent */
   private getSeverity(severity: DiagnosticSeverity): monacoAPI.MarkerSeverity {
     switch (severity) {
       case DiagnosticSeverity.Error: return MarkerSeverity.Error;
@@ -383,6 +384,7 @@ export class EditorService extends AbstractService {
       default: return 'diagnostic-warning';
     }
   }
+  /* eslint-enable indent */
 
   private fileName = 'asyncapi';
   private downloadFile(content: string, fileName: string) {

--- a/apps/studio/src/services/editor.service.tsx
+++ b/apps/studio/src/services/editor.service.tsx
@@ -18,7 +18,7 @@ export interface UpdateState {
   updateModel?: boolean;
   sendToServer?: boolean;
   file?: Partial<File>;
-} 
+}
 
 export class EditorService extends AbstractService {
   private created = false;
@@ -26,7 +26,7 @@ export class EditorService extends AbstractService {
   private instance: monacoAPI.editor.IStandaloneCodeEditor | undefined;
 
   override onInit() {
-    this.subcribeToDocuments();
+    this.subscribeToDocuments();
   }
 
   async onDidCreate(editor: monacoAPI.editor.IStandaloneCodeEditor) {
@@ -43,13 +43,13 @@ export class EditorService extends AbstractService {
     } else {
       this.applyMarkersAndDecorations(document.diagnostics.filtered);
     }
-    
+
     // apply save command
     editor.addCommand(
       KeyMod.CtrlCmd | KeyCode.KeyS,
       () => this.saveToLocalStorage(),
     );
-    
+
     appState.setState({ initialized: true });
   }
 
@@ -107,12 +107,12 @@ export class EditorService extends AbstractService {
       return fetch(url)
         .then(res => res.text())
         .then(async text => {
-          this.updateState({ 
-            content: text, 
-            updateModel: true, 
-            file: { 
-              source: url, 
-              from: 'url' 
+          this.updateState({
+            content: text,
+            updateModel: true,
+            file: {
+              source: url,
+              from: 'url'
             },
           });
         })
@@ -131,7 +131,7 @@ export class EditorService extends AbstractService {
     if (!file) {
       return;
     }
-    
+
     // Check if file is valid (only JSON and YAML are allowed currently) ----Change afterwards as per the requirement
     if (
       file.type !== 'application/json' &&
@@ -152,12 +152,12 @@ export class EditorService extends AbstractService {
   async importBase64(content: string) {
     try {
       const decoded = this.svcs.formatSvc.decodeBase64(content);
-      this.updateState({ 
-        content: String(decoded), 
-        updateModel: true, 
-        file: { 
-          from: 'base64', 
-          source: undefined, 
+      this.updateState({
+        content: String(decoded),
+        updateModel: true,
+        file: {
+          from: 'base64',
+          source: undefined,
         },
       });
     } catch (err) {
@@ -174,12 +174,12 @@ export class EditorService extends AbstractService {
       }
 
       const data = await response.json();
-      this.updateState({ 
-        content: data.content, 
-        updateModel: true, 
-        file: { 
-          from: 'share', 
-          source: undefined, 
+      this.updateState({
+        content: data.content,
+        updateModel: true,
+        file: {
+          from: 'share',
+          source: undefined,
         },
       });
     } catch (err) {
@@ -219,9 +219,9 @@ export class EditorService extends AbstractService {
     try {
       const yamlContent = this.svcs.formatSvc.convertToYaml(this.value);
       if (yamlContent) {
-        this.updateState({ 
-          content: yamlContent, 
-          updateModel: true, 
+        this.updateState({
+          content: yamlContent,
+          updateModel: true,
           file: {
             language: 'yaml',
           }
@@ -237,9 +237,9 @@ export class EditorService extends AbstractService {
     try {
       const jsonContent = this.svcs.formatSvc.convertToJSON(this.value);
       if (jsonContent) {
-        this.updateState({ 
-          content: jsonContent, 
-          updateModel: true, 
+        this.updateState({
+          content: jsonContent,
+          updateModel: true,
           file: {
             language: 'json',
           }
@@ -339,7 +339,7 @@ export class EditorService extends AbstractService {
           id: 'asyncapi',
           ownerId: 0,
           range: new Range(
-            range.start.line + 1, 
+            range.start.line + 1,
             range.start.character + 1,
             range.end.line + 1,
             range.end.character + 1
@@ -351,7 +351,7 @@ export class EditorService extends AbstractService {
         });
         return;
       }
-  
+
       newMarkers.push({
         startLineNumber: range.start.line + 1,
         startColumn: range.start.character + 1,
@@ -367,20 +367,20 @@ export class EditorService extends AbstractService {
 
   private getSeverity(severity: DiagnosticSeverity): monacoAPI.MarkerSeverity {
     switch (severity) {
-    case DiagnosticSeverity.Error: return MarkerSeverity.Error;
-    case DiagnosticSeverity.Warning: return MarkerSeverity.Warning;
-    case DiagnosticSeverity.Information: return MarkerSeverity.Info;
-    case DiagnosticSeverity.Hint: return MarkerSeverity.Hint;
-    default: return MarkerSeverity.Error;
+      case DiagnosticSeverity.Error: return MarkerSeverity.Error;
+      case DiagnosticSeverity.Warning: return MarkerSeverity.Warning;
+      case DiagnosticSeverity.Information: return MarkerSeverity.Info;
+      case DiagnosticSeverity.Hint: return MarkerSeverity.Hint;
+      default: return MarkerSeverity.Error;
     }
   }
 
   private getSeverityClassName(severity: DiagnosticSeverity): string {
     switch (severity) {
-    case DiagnosticSeverity.Warning: return 'diagnostic-warning';
-    case DiagnosticSeverity.Information: return 'diagnostic-information';
-    case DiagnosticSeverity.Hint: return 'diagnostic-hint';
-    default: return 'diagnostic-warning';
+      case DiagnosticSeverity.Warning: return 'diagnostic-warning';
+      case DiagnosticSeverity.Information: return 'diagnostic-information';
+      case DiagnosticSeverity.Hint: return 'diagnostic-hint';
+      default: return 'diagnostic-warning';
     }
   }
 
@@ -389,7 +389,7 @@ export class EditorService extends AbstractService {
     return fileDownload(content, fileName);
   }
 
-  private subcribeToDocuments() {
+  private subscribeToDocuments() {
     documentsState.subscribe((state, prevState) => {
       const newDocuments = state.documents;
       const oldDocuments = prevState.documents;

--- a/apps/studio/src/services/monaco.service.ts
+++ b/apps/studio/src/services/monaco.service.ts
@@ -27,7 +27,7 @@ export class MonacoService extends AbstractService {
     // load initial language config (for json and yaml)
     this.setLanguageConfig(this.svcs.specificationSvc.latestVersion);
     // subscribe to document to update JSON/YAML language config
-    this.subcribeToDocuments();
+    this.subscribeToDocuments();
   }
 
   get monaco() {
@@ -85,7 +85,7 @@ export class MonacoService extends AbstractService {
     if (process.env.NODE_ENV === 'test') {
       return;
     }
-    
+
     const monaco = this.monacoInstance = await import('monaco-editor');
     loader.config({ monaco });
   }
@@ -124,7 +124,7 @@ export class MonacoService extends AbstractService {
       }
 
       return {
-        uri, 
+        uri,
         schema,
       };
     });
@@ -158,7 +158,7 @@ export class MonacoService extends AbstractService {
     })) as JSONSchema7;
   }
 
-  private subcribeToDocuments() {
+  private subscribeToDocuments() {
     documentsState.subscribe((state, prevState) => {
       const newDocuments = state.documents;
       const oldDocuments = prevState.documents;

--- a/apps/studio/src/services/specification.service.ts
+++ b/apps/studio/src/services/specification.service.ts
@@ -12,7 +12,7 @@ import type { SpecVersions } from '../types';
 export class SpecificationService extends AbstractService {
   private keySessionStorage = 'informed-about-latest';
   override onInit() {
-    this.subcribeToDocuments();
+    this.subscribeToDocuments();
     this.subscribeToSettings();
   }
 
@@ -21,14 +21,14 @@ export class SpecificationService extends AbstractService {
   }
 
   get latestVersion(): SpecVersions {
-    return  Object.keys(this.specs).pop() as SpecVersions;
+    return Object.keys(this.specs).pop() as SpecVersions;
   }
 
   getSpec(version: SpecVersions) {
     return this.specs[String(version) as SpecVersions];
   }
 
-  private subcribeToDocuments() {
+  private subscribeToDocuments() {
     documentsState.subscribe((state, prevState) => {
       const newDocuments = state.documents;
       const oldDocuments = prevState.documents;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "dev": "tsup --watch"
   },
   "keywords": [],
   "author": "",

--- a/turbo.json
+++ b/turbo.json
@@ -1,21 +1,36 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["**/.env.*local"],
+  "globalDependencies": [
+    "**/.env.*local"
+  ],
   "pipeline": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", "storybook-static/**"],
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        "storybook-static/**"
+      ],
       "cache": false
     },
     "dev": {
+      "dependsOn": [
+        "^build"
+      ],
       "cache": false,
       "persistent": true
     },
     "release": {
-      "dependsOn": ["build"]
+      "dependsOn": [
+        "build"
+      ]
     },
     "test": {
-      "dependsOn": ["lint", "generate:assets"]
+      "dependsOn": [
+        "lint",
+        "generate:assets"
+      ]
     },
     "clean": {},
     "lint": {},


### PR DESCRIPTION

**Description**
Problem solved : There is a private method subscribeToDocuments defined in each of these three services file with typo mistake as subcribeToDocuments`  .Now it has been fixed.
Any issue raised before opening this PR :No as this issue is very straightforward.I directly opened its PR !

- Renamed `subcribeToDocuments` to [subscribeToDocuments](cci:1://file:///d:/Projects/gsoc/studio/apps/studio/src/services/monaco.service.ts:160:2-184:3) in [SpecificationService](cci:2://file:///d:/Projects/gsoc/studio/apps/studio/src/services/specification.service.ts:11:0-74:1).
- Renamed `subcribeToDocuments` to [subscribeToDocuments](cci:1://file:///d:/Projects/gsoc/studio/apps/studio/src/services/monaco.service.ts:160:2-184:3) in [MonacoService](cci:2://file:///d:/Projects/gsoc/studio/apps/studio/src/services/monaco.service.ts:13:0-185:1).
- Renamed `subcribeToDocuments` to [subscribeToDocuments](cci:1://file:///d:/Projects/gsoc/studio/apps/studio/src/services/monaco.service.ts:160:2-184:3) in [EditorService](cci:2://file:///d:/Projects/gsoc/studio/apps/studio/src/services/editor.service.tsx:22:0-403:1).

Screenshots : 
<img width="1860" height="806" alt="image" src="https://github.com/user-attachments/assets/c8fff944-d1f6-428b-ae98-150bff93334b" />
