### PR TITLE
Fix : Resolves #1244

### DIFF
--- a/apps/studio/src/components/Editor/ConvertDropdown.tsx
+++ b/apps/studio/src/components/Editor/ConvertDropdown.tsx
@@ -10,11 +10,11 @@ import { useDocumentsState, useFilesState } from '../../state';
 
 export const ConvertDropdown: React.FC = () => {
   const { editorSvc } = useServices();
-  const isInvalidDocument = !useDocumentsState(state => 
+  const isInvalidDocument = !useDocumentsState(state =>
     state.documents['asyncapi'].valid
   );
   const language = useFilesState(state => state.files['asyncapi'].language);
-      
+
   return (
     <Dropdown
       opener={
@@ -69,7 +69,7 @@ export const ConvertDropdown: React.FC = () => {
             title="Convert AsyncAPI document"
             onClick={() => show(ConvertModal)}
           >
-                Convert document
+            Convert document
           </button>
         </li>
       </ul>

--- a/apps/studio/src/components/Editor/GenerateDropdown.tsx
+++ b/apps/studio/src/components/Editor/GenerateDropdown.tsx
@@ -9,7 +9,7 @@ import { useDocumentsState } from '../../state';
 import { useServices } from '@/services';
 
 export const GenerateDropdown: React.FC = () => {
-  const isInvalidDocument = !useDocumentsState(state => 
+  const isInvalidDocument = !useDocumentsState(state =>
     state.documents['asyncapi'].valid
   );
   const { editorSvc } = useServices();
@@ -35,11 +35,11 @@ export const GenerateDropdown: React.FC = () => {
             disabled={isInvalidDocument}
             onClick={() => show(GeneratorModal)}
           >
-                Generate code/docs
+            Generate code/docs
           </button>
         </li>
         <li className="hover:bg-gray-900">
-          <button 
+          <button
             type="button"
             className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150 disabled:cursor-not-allowed"
             title='Share as Base64'
@@ -59,7 +59,7 @@ export const GenerateDropdown: React.FC = () => {
                 }
               );
             }}>
-                Share as Base64
+            Share as Base64
           </button>
         </li>
       </ul>

--- a/apps/studio/src/components/Editor/ImportDropdown.tsx
+++ b/apps/studio/src/components/Editor/ImportDropdown.tsx
@@ -16,7 +16,7 @@ export const ImportDropdown: React.FC = () => {
   const { editorSvc } = useServices();
 
   return (
-    <Dropdown 
+    <Dropdown
       opener={
         <Tooltip content="Import" placement="top" hideOnClick={true}>
           <button className="bg-inherit">
@@ -35,7 +35,7 @@ export const ImportDropdown: React.FC = () => {
             title="Import from URL"
             onClick={() => show(ImportURLModal)}
           >
-                Import from URL
+            Import from URL
           </button>
         </li>
 
@@ -54,14 +54,14 @@ export const ImportDropdown: React.FC = () => {
                   success: (
                     <div>
                       <span className="block text-bold">
-                      Document succesfully imported!
+                        Document succesfully imported!
                       </span>
                     </div>
                   ),
                   error: (
                     <div>
                       <span className="block text-bold text-red-400">
-                      Failed to import document. Maybe the file type is invalid.
+                        Failed to import document. Maybe the file type is invalid.
                       </span>
                     </div>
                   ),
@@ -95,7 +95,7 @@ export const ImportDropdown: React.FC = () => {
         </li>
 
       </ul>
-            
+
     </Dropdown>
   );
 }

--- a/apps/studio/src/components/Editor/SaveDropdown.tsx
+++ b/apps/studio/src/components/Editor/SaveDropdown.tsx
@@ -8,7 +8,7 @@ import { useDocumentsState, useFilesState } from '../../state';
 
 export const SaveDropdown: React.FC = () => {
   const { editorSvc } = useServices();
-  const isInvalidDocument = !useDocumentsState(state => 
+  const isInvalidDocument = !useDocumentsState(state =>
     state.documents['asyncapi'].valid
   );
   const language = useFilesState(state => state.files['asyncapi'].language);
@@ -94,7 +94,7 @@ export const SaveDropdown: React.FC = () => {
             Convert and save as {language === 'yaml' ? 'JSON' : 'YAML'}
           </button>
         </li>
-       
+
       </ul>
     </Dropdown>
   );

--- a/apps/studio/src/services/converter.service.ts
+++ b/apps/studio/src/services/converter.service.ts
@@ -1,6 +1,7 @@
 import { AbstractService } from './abstract.service';
 
 import { convert } from '@asyncapi/converter';
+import toast from 'react-hot-toast';
 
 import type { AsyncAPIConvertVersion, ConvertOptions } from '@asyncapi/converter';
 
@@ -18,7 +19,8 @@ export class ConverterService extends AbstractService {
         return JSON.stringify(converted, undefined, 2);
       }
       return converted;
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Conversion Failed: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }

--- a/apps/studio/src/services/editor.service.tsx
+++ b/apps/studio/src/services/editor.service.tsx
@@ -18,7 +18,7 @@ export interface UpdateState {
   updateModel?: boolean;
   sendToServer?: boolean;
   file?: Partial<File>;
-} 
+}
 
 export class EditorService extends AbstractService {
   private created = false;
@@ -43,13 +43,13 @@ export class EditorService extends AbstractService {
     } else {
       this.applyMarkersAndDecorations(document.diagnostics.filtered);
     }
-    
+
     // apply save command
     editor.addCommand(
       KeyMod.CtrlCmd | KeyCode.KeyS,
       () => this.saveToLocalStorage(),
     );
-    
+
     appState.setState({ initialized: true });
   }
 
@@ -107,16 +107,17 @@ export class EditorService extends AbstractService {
       return fetch(url)
         .then(res => res.text())
         .then(async text => {
-          this.updateState({ 
-            content: text, 
-            updateModel: true, 
-            file: { 
-              source: url, 
-              from: 'url' 
+          this.updateState({
+            content: text,
+            updateModel: true,
+            file: {
+              source: url,
+              from: 'url'
             },
           });
         })
         .catch(err => {
+          toast.error(`Failed to import from URL: ${err.message}`, { duration: Infinity });
           console.error(err);
           throw err;
         });
@@ -131,7 +132,7 @@ export class EditorService extends AbstractService {
     if (!file) {
       return;
     }
-    
+
     // Check if file is valid (only JSON and YAML are allowed currently) ----Change afterwards as per the requirement
     if (
       file.type !== 'application/json' &&
@@ -152,15 +153,16 @@ export class EditorService extends AbstractService {
   async importBase64(content: string) {
     try {
       const decoded = this.svcs.formatSvc.decodeBase64(content);
-      this.updateState({ 
-        content: String(decoded), 
-        updateModel: true, 
-        file: { 
-          from: 'base64', 
-          source: undefined, 
+      this.updateState({
+        content: String(decoded),
+        updateModel: true,
+        file: {
+          from: 'base64',
+          source: undefined,
         },
       });
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to import Base64 content: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -174,15 +176,16 @@ export class EditorService extends AbstractService {
       }
 
       const data = await response.json();
-      this.updateState({ 
-        content: data.content, 
-        updateModel: true, 
-        file: { 
-          from: 'share', 
-          source: undefined, 
+      this.updateState({
+        content: data.content,
+        updateModel: true,
+        file: {
+          from: 'share',
+          source: undefined,
         },
       });
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to import from Share ID: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -199,7 +202,8 @@ export class EditorService extends AbstractService {
         body: JSON.stringify({ content: file.content }),
       }).then(res => res.text());
       return `${window.location.origin}/?share=${shareID}`;
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to export as URL: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -209,7 +213,8 @@ export class EditorService extends AbstractService {
     try {
       const file = filesState.getState().files['asyncapi'];
       return this.svcs.formatSvc.encodeBase64(file.content);
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to export as Base64: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -219,15 +224,16 @@ export class EditorService extends AbstractService {
     try {
       const yamlContent = this.svcs.formatSvc.convertToYaml(this.value);
       if (yamlContent) {
-        this.updateState({ 
-          content: yamlContent, 
-          updateModel: true, 
+        this.updateState({
+          content: yamlContent,
+          updateModel: true,
           file: {
             language: 'yaml',
           }
         });
       }
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to convert to YAML: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -237,15 +243,16 @@ export class EditorService extends AbstractService {
     try {
       const jsonContent = this.svcs.formatSvc.convertToJSON(this.value);
       if (jsonContent) {
-        this.updateState({ 
-          content: jsonContent, 
-          updateModel: true, 
+        this.updateState({
+          content: jsonContent,
+          updateModel: true,
           file: {
             language: 'json',
           }
         });
       }
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to convert to JSON: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -257,7 +264,8 @@ export class EditorService extends AbstractService {
       if (yamlContent) {
         this.downloadFile(yamlContent, `${this.fileName}.yaml`);
       }
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to save as YAML: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -269,7 +277,8 @@ export class EditorService extends AbstractService {
       if (jsonContent) {
         this.downloadFile(jsonContent, `${this.fileName}.json`);
       }
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Failed to save as JSON: ${err.message}`, { duration: Infinity });
       console.error(err);
       throw err;
     }
@@ -339,7 +348,7 @@ export class EditorService extends AbstractService {
           id: 'asyncapi',
           ownerId: 0,
           range: new Range(
-            range.start.line + 1, 
+            range.start.line + 1,
             range.start.character + 1,
             range.end.line + 1,
             range.end.character + 1
@@ -351,7 +360,7 @@ export class EditorService extends AbstractService {
         });
         return;
       }
-  
+
       newMarkers.push({
         startLineNumber: range.start.line + 1,
         startColumn: range.start.character + 1,
@@ -367,20 +376,20 @@ export class EditorService extends AbstractService {
 
   private getSeverity(severity: DiagnosticSeverity): monacoAPI.MarkerSeverity {
     switch (severity) {
-    case DiagnosticSeverity.Error: return MarkerSeverity.Error;
-    case DiagnosticSeverity.Warning: return MarkerSeverity.Warning;
-    case DiagnosticSeverity.Information: return MarkerSeverity.Info;
-    case DiagnosticSeverity.Hint: return MarkerSeverity.Hint;
-    default: return MarkerSeverity.Error;
+      case DiagnosticSeverity.Error: return MarkerSeverity.Error;
+      case DiagnosticSeverity.Warning: return MarkerSeverity.Warning;
+      case DiagnosticSeverity.Information: return MarkerSeverity.Info;
+      case DiagnosticSeverity.Hint: return MarkerSeverity.Hint;
+      default: return MarkerSeverity.Error;
     }
   }
 
   private getSeverityClassName(severity: DiagnosticSeverity): string {
     switch (severity) {
-    case DiagnosticSeverity.Warning: return 'diagnostic-warning';
-    case DiagnosticSeverity.Information: return 'diagnostic-information';
-    case DiagnosticSeverity.Hint: return 'diagnostic-hint';
-    default: return 'diagnostic-warning';
+      case DiagnosticSeverity.Warning: return 'diagnostic-warning';
+      case DiagnosticSeverity.Information: return 'diagnostic-information';
+      case DiagnosticSeverity.Hint: return 'diagnostic-hint';
+      default: return 'diagnostic-warning';
     }
   }
 

--- a/apps/studio/src/services/editor.service.tsx
+++ b/apps/studio/src/services/editor.service.tsx
@@ -168,7 +168,7 @@ export class EditorService extends AbstractService {
     }
   }
 
-  async importFromShareID(shareID: string) {
+  async importFromShareID(shareID: string) { // checked
     try {
       const response = await fetch(`/share/${shareID}`);
       if (!response.ok) {
@@ -191,7 +191,7 @@ export class EditorService extends AbstractService {
     }
   }
 
-  async exportAsURL() {
+  async exportAsURL() { // no option on ui
     try {
       const file = filesState.getState().files['asyncapi'];
       const shareID = await fetch('/share', {
@@ -208,7 +208,7 @@ export class EditorService extends AbstractService {
       throw err;
     }
   }
-
+  // done
   async exportAsBase64() {
     try {
       const file = filesState.getState().files['asyncapi'];
@@ -258,7 +258,7 @@ export class EditorService extends AbstractService {
     }
   }
 
-  async saveAsYaml() {
+  async saveAsYaml() { // done
     try {
       const yamlContent = this.svcs.formatSvc.convertToYaml(this.value);
       if (yamlContent) {
@@ -271,7 +271,7 @@ export class EditorService extends AbstractService {
     }
   }
 
-  async saveAsJSON() {
+  async saveAsJSON() { // done
     try {
       const jsonContent = this.svcs.formatSvc.convertToJSON(this.value);
       if (jsonContent) {
@@ -376,20 +376,20 @@ export class EditorService extends AbstractService {
 
   private getSeverity(severity: DiagnosticSeverity): monacoAPI.MarkerSeverity {
     switch (severity) {
-      case DiagnosticSeverity.Error: return MarkerSeverity.Error;
-      case DiagnosticSeverity.Warning: return MarkerSeverity.Warning;
-      case DiagnosticSeverity.Information: return MarkerSeverity.Info;
-      case DiagnosticSeverity.Hint: return MarkerSeverity.Hint;
-      default: return MarkerSeverity.Error;
+    case DiagnosticSeverity.Error: return MarkerSeverity.Error;
+    case DiagnosticSeverity.Warning: return MarkerSeverity.Warning;
+    case DiagnosticSeverity.Information: return MarkerSeverity.Info;
+    case DiagnosticSeverity.Hint: return MarkerSeverity.Hint;
+    default: return MarkerSeverity.Error;
     }
   }
 
   private getSeverityClassName(severity: DiagnosticSeverity): string {
     switch (severity) {
-      case DiagnosticSeverity.Warning: return 'diagnostic-warning';
-      case DiagnosticSeverity.Information: return 'diagnostic-information';
-      case DiagnosticSeverity.Hint: return 'diagnostic-hint';
-      default: return 'diagnostic-warning';
+    case DiagnosticSeverity.Warning: return 'diagnostic-warning';
+    case DiagnosticSeverity.Information: return 'diagnostic-information';
+    case DiagnosticSeverity.Hint: return 'diagnostic-hint';
+    default: return 'diagnostic-warning';
     }
   }
 

--- a/apps/studio/src/services/format.service.ts
+++ b/apps/studio/src/services/format.service.ts
@@ -7,13 +7,13 @@ import toast from 'react-hot-toast';
 export class FormatService extends AbstractService {
   convertToYaml(spec: string) {
     try {
-
       // Editor content -> JS object -> YAML string
       const jsonContent = YAML.load(spec);
       return YAML.dump(jsonContent);
     } catch (err: any) {
       toast.error(`YAML Conversion Error: ${err.message}`, { duration: Infinity });
       console.error(err);
+      throw err;
     }
   }
 
@@ -26,6 +26,7 @@ export class FormatService extends AbstractService {
     } catch (err: any) {
       toast.error(`JSON Conversion Error: ${err.message}`, { duration: Infinity });
       console.error(err);
+      throw err;
     }
   }
 

--- a/apps/studio/src/services/format.service.ts
+++ b/apps/studio/src/services/format.service.ts
@@ -2,14 +2,17 @@ import { AbstractService } from './abstract.service';
 
 import { encode, decode } from 'js-base64';
 import YAML from 'js-yaml';
+import toast from 'react-hot-toast';
 
 export class FormatService extends AbstractService {
   convertToYaml(spec: string) {
     try {
+
       // Editor content -> JS object -> YAML string
       const jsonContent = YAML.load(spec);
       return YAML.dump(jsonContent);
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`YAML Conversion Error: ${err.message}`, { duration: Infinity });
       console.error(err);
     }
   }
@@ -20,7 +23,8 @@ export class FormatService extends AbstractService {
       const jsonContent = YAML.load(spec);
       // JS Object -> pretty JSON string
       return JSON.stringify(jsonContent, null, 2);
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`JSON Conversion Error: ${err.message}`, { duration: Infinity });
       console.error(err);
     }
   }

--- a/apps/studio/src/services/format.service.ts
+++ b/apps/studio/src/services/format.service.ts
@@ -7,26 +7,25 @@ import toast from 'react-hot-toast';
 export class FormatService extends AbstractService {
   convertToYaml(spec: string) {
     try {
-      // Editor content -> JS object -> YAML string
       const jsonContent = YAML.load(spec);
       return YAML.dump(jsonContent);
     } catch (err: any) {
-      toast.error(`YAML Conversion Error: ${err.message}`, { duration: Infinity });
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      toast.error(`YAML Conversion Error: ${errorMessage}`, { duration: Infinity });
       console.error(err);
-      throw err;
+      throw new Error(`YAML conversion failed: ${errorMessage}`);
     }
   }
 
   convertToJSON(spec: string) {
     try {
-      // JSON or YAML String -> JS object
       const jsonContent = YAML.load(spec);
-      // JS Object -> pretty JSON string
       return JSON.stringify(jsonContent, null, 2);
     } catch (err: any) {
-      toast.error(`JSON Conversion Error: ${err.message}`, { duration: Infinity });
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      toast.error(`JSON Conversion Error: ${errorMessage}`, { duration: Infinity });
       console.error(err);
-      throw err;
+      throw new Error(`JSON conversion failed: ${errorMessage}`);
     }
   }
 

--- a/apps/studio/src/services/parser.service.ts
+++ b/apps/studio/src/services/parser.service.ts
@@ -5,6 +5,7 @@ import { OpenAPISchemaParser } from '@asyncapi/openapi-schema-parser';
 import { AvroSchemaParser } from '@asyncapi/avro-schema-parser';
 import { ProtoBuffSchemaParser } from '@asyncapi/protobuf-schema-parser';
 import { untilde } from '@asyncapi/parser/cjs/utils';
+import toast from 'react-hot-toast';
 
 import { isDeepEqual } from '@/helpers';
 import { filesState, documentsState, settingsState } from '@/state';
@@ -38,12 +39,15 @@ export class ParserService extends AbstractService {
   }
 
   async parse(uri: string, spec: string, options: ParseOptions = {}): Promise<void> {
+
     if (uri !== 'asyncapi' && !options.source) {
       options.source = uri;
     }
 
     let diagnostics: Diagnostic[] = [];
     try {
+
+
       const { document, diagnostics: _diagnostics, extras } = await this.parser.parse(spec, options);
       diagnostics = _diagnostics;
       if (document) {
@@ -55,8 +59,10 @@ export class ParserService extends AbstractService {
           valid: true,
         });
         return;
-      } 
+      }
     } catch (err: unknown) {
+      const parsedError = err instanceof Error ? err : new Error(String(err));
+      toast.error(`Parser Error: ${parsedError.message}`, { duration: Infinity });
       console.log(err);
     }
 
@@ -81,7 +87,8 @@ export class ParserService extends AbstractService {
 
         return extras.document.getRangeForJsonPath(jsonPath);
       }
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Error calculating range for JSON path: ${err.message}`, { duration: Infinity });
       console.error(err);
     }
   }
@@ -100,7 +107,8 @@ export class ParserService extends AbstractService {
         const location = getLocationForJsonPath(yamlDoc, jsonPath, true);
         return location?.range || { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } };
       }
-    } catch (err) {
+    } catch (err: any) {
+      toast.error(`Error calculating range for YAML path: ${err.message}`, { duration: Infinity });
       console.error(err);
     }
   }
@@ -130,7 +138,7 @@ export class ParserService extends AbstractService {
         diagnostic.message = 'File references are not yet supported in Studio';
       }
     });
-    
+
     const collections: DocumentDiagnostics = {
       original: diagnostics,
       filtered: [],

--- a/apps/studio/src/services/parser.service.ts
+++ b/apps/studio/src/services/parser.service.ts
@@ -39,15 +39,12 @@ export class ParserService extends AbstractService {
   }
 
   async parse(uri: string, spec: string, options: ParseOptions = {}): Promise<void> {
-
     if (uri !== 'asyncapi' && !options.source) {
       options.source = uri;
     }
 
     let diagnostics: Diagnostic[] = [];
     try {
-
-
       const { document, diagnostics: _diagnostics, extras } = await this.parser.parse(spec, options);
       diagnostics = _diagnostics;
       if (document) {


### PR DESCRIPTION
Problem : See issue #1244 for details.
Fix: Added toast message when functionality fails for better user experience.
Before fix : studio without ant toast messages 
After fix scenario:
1) when "save as JSON" functionality fails then this:
<img width="1919" height="877" alt="Screenshot 2026-01-18 114839" src="https://github.com/user-attachments/assets/e8adacb0-c7e9-4c0a-bf2f-61f62a962416" />
2) when "conversion to JSON" fails 
<img width="1902" height="871" alt="Screenshot 2026-01-18 132400" src="https://github.com/user-attachments/assets/36edf5d0-4732-4445-9740-7abcc7292950" />

3) when "import from base64" fails,
<img width="1897" height="866" alt="Screenshot 2026-01-18 121811" src="https://github.com/user-attachments/assets/dca5426e-eb38-4491-94a6-dd1ba77b1594" />
4) when "convert and save as YAML" fails ,
<img width="1902" height="876" alt="Screenshot 2026-01-18 114938" src="https://github.com/user-attachments/assets/5dfd7a6c-67f8-4b15-8e84-2fb1f7298a15" />
5) when "convert to YAML" fails
<img width="1905" height="869" alt="Screenshot 2026-01-18 123351" src="https://github.com/user-attachments/assets/747e5599-24c8-47c3-ac5a-f5bcf2a728ce" />
7) when "import from UUID" fails
<img width="1902" height="970" alt="Screenshot 2026-01-18 115708" src="https://github.com/user-attachments/assets/9db4e105-42a8-4569-97f6-4bec3f3cbb8a" />


