### PR TITLE
fix: swap PUB/SUB badges in sidebar

### DIFF
--- a/apps/studio/src/components/Navigation.tsx
+++ b/apps/studio/src/components/Navigation.tsx
@@ -115,8 +115,8 @@ const OperationsNavigation: React.FunctionComponent<NavigationSectionProps> = ({
           >
             <div className="flex flex-row">
               <div className="flex-none">
-                <span className="mr-3 text-xs uppercase text-blue-500 font-bold">
-                  Pub
+                <span className="mr-3 text-xs uppercase text-green-600 font-bold">
+                  Sub
                 </span>
               </div>
               <span className="truncate">{channelName}</span>
@@ -147,8 +147,8 @@ const OperationsNavigation: React.FunctionComponent<NavigationSectionProps> = ({
           >
             <div className="flex flex-row">
               <div className="flex-none">
-                <span className="mr-3 text-xs uppercase text-green-600 font-bold">
-                  Sub
+                <span className="mr-3 text-xs uppercase text-blue-500 font-bold">
+                  Pub
                 </span>
               </div>
               <span className="truncate">{channelName}</span>


### PR DESCRIPTION
**Description**
- Fixed the mixed-up PUB/SUB badges in the sidebar navigation.
- **Receive** operations now show a **SUB** (Green) badge, aligning with the concept that if the application receives a message, it is subscribing to a channel.
- **Send** operations now show a **PUB** (Blue) badge, aligning with the concept that if the application sends a message, it is publishing to a channel.
- This corrects the previous behavior where the badges were inverted based on the AsyncAPI specification keywords.
Fixes "Mixed-up PUB/SUB labels" issue reported by Razorlightqt.