### PR TITLE
Fix/windows silent build error

### DIFF
--- a/apps/studio/src/components/Navigation.tsx
+++ b/apps/studio/src/components/Navigation.tsx
@@ -115,8 +115,8 @@ const OperationsNavigation: React.FunctionComponent<NavigationSectionProps> = ({
           >
             <div className="flex flex-row">
               <div className="flex-none">
-                <span className="mr-3 text-xs uppercase text-blue-500 font-bold">
-                  Pub
+                <span className="mr-3 text-xs uppercase text-green-600 font-bold">
+                  Sub
                 </span>
               </div>
               <span className="truncate">{channelName}</span>
@@ -147,8 +147,8 @@ const OperationsNavigation: React.FunctionComponent<NavigationSectionProps> = ({
           >
             <div className="flex flex-row">
               <div className="flex-none">
-                <span className="mr-3 text-xs uppercase text-green-600 font-bold">
-                  Sub
+                <span className="mr-3 text-xs uppercase text-blue-500 font-bold">
+                  Pub
                 </span>
               </div>
               <span className="truncate">{channelName}</span>

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "private": true,
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "dev": "tsup --watch"
   },
   "keywords": [],
   "author": "",

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
       "cache": false
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
Fixed a build race condition on Windows where @asyncapi/studio-ui would attempt to build before its dependency 
@asyncapi/studio-utils was ready.

- Updated  turbo.json to make the dev pipeline depend on ^build, ensuring that all upstream dependencies are built before a package's dev script runs.
- Added a dev script (tsup --watch) to packages/utils/package.json so it runs in watch mode during development.

Verified locally on Windows that this resolves the "Could not resolve @asyncapi/studio-utils" error and ensures the correct build order.

Related issue(s) Fixes #1243