### PR TITLE
fix(ui): align pop-up and settings dialog colors with dark blue theme

### DIFF
--- a/apps/studio/src/components/Modals/ConfirmModal.tsx
+++ b/apps/studio/src/components/Modals/ConfirmModal.tsx
@@ -95,17 +95,17 @@ export const ConfirmModal: FunctionComponent<PropsWithChildren<ConfirmModalProps
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <div className={`inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl w-2/5 sm:p-6 ${containerClassName}`}>
+              <div className={`inline-block align-bottom bg-gray-900 rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl w-2/5 sm:p-6 ${containerClassName}`}>
                 <div>
                   <div>
                     <Dialog.Title
                       as="h3"
-                      className="text-lg leading-6 font-medium text-gray-900"
+                      className="text-lg leading-6 font-medium text-gray-100"
                     >
                       {title}
                     </Dialog.Title>
                     {description && (
-                      <p className="text-gray-500 text-xs">{description}</p>
+                      <p className="text-gray-200 text-xs">{description}</p>
                     )}
                     {warning && (
                       <a

--- a/apps/studio/src/components/Modals/ConfirmNewFileModal.tsx
+++ b/apps/studio/src/components/Modals/ConfirmNewFileModal.tsx
@@ -19,7 +19,7 @@ export const ConfirmNewFileModal = create(() => {
       <div className="flex content-center justify-center flex-col">
         <div className="w-full  overflow-auto">
           <div>
-                        Would you like to create a new file?
+            <span className="text-gray-200">Would you like to create a new file?</span>
             <p>
               <b className='text-pink-500'>All the existing changes will be lost and overwritten.</b>
             </p>

--- a/apps/studio/src/components/Modals/Settings/SettingsModal.tsx
+++ b/apps/studio/src/components/Modals/Settings/SettingsModal.tsx
@@ -29,7 +29,7 @@ const ShowGovernanceOption: FunctionComponent<ShowGovernanceOptionProps> = ({
         <div className="flex flex-row content-center justify-between">
           <label
             htmlFor={`settings-governance-show-${label}`}
-            className="flex justify-right items-center w-1/2 content-center font-medium text-gray-700"
+            className="flex justify-right items-center w-1/2 content-center font-medium text-gray-200"
           >
             Show&nbsp;<strong>{label}</strong>&nbsp;governance issues
           </label>
@@ -132,7 +132,7 @@ export const SettingsModal = create<SettingsModalProps>(({ activeTab = 'editor' 
             <div className="flex flex-row content-center justify-between">
               <label
                 htmlFor="asyncapi-version"
-                className="flex justify-right items-center w-1/2 content-center font-medium text-gray-700"
+                className="flex justify-right items-center w-1/2 content-center font-medium text-gray-200"
               >
                 Auto rendering
               </label>

--- a/apps/studio/src/components/Modals/Settings/SettingsTabs.tsx
+++ b/apps/studio/src/components/Modals/Settings/SettingsTabs.tsx
@@ -28,9 +28,9 @@ export const SettingsTabs: FunctionComponent<SettingTabsProps> = ({
   return (
     <div>
       <div
-        className="flex flex-row justify-between items-center border-b border-gray-300 text-white uppercase font-bold text-xs"
+        className="flex flex-row justify-between items-center border-b-2 border-gray-400 text-white uppercase font-bold text-xs"
       >
-        <ul className="flex flex-row">
+        <ul className="flex flex-row -mb-[2px]">
           {tabs.map(tab => (
             <li
               key={tab.name}
@@ -46,7 +46,7 @@ export const SettingsTabs: FunctionComponent<SettingTabsProps> = ({
                 className={`p-2 hover:text-pink-500 ${
                   activeTab === tab.name
                     ? 'text-pink-500 border-b-2 border-pink-500'
-                    : 'text-gray-500'
+                    : 'text-gray-200'
                 }`}
               >
                 {tab.tab}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- added dark theme in some missing components of the website
- I redesigned the UI, I have used gray-800 instead of a black to match the existing grey-700 used by editor
- Made UI improvement to the active tab indicator in setting pop up.


**Related issue(s)**
Fixes #1256 

## BEFORE: 

<img width="655" height="285" alt="Screenshot 2026-08-03 at 1 32 34 AM" src="https://github.com/user-attachments/assets/716dccda-20fa-48ea-9eb6-0b953088e235" />

<img width="711" height="511" alt="Screenshot 2026-08-03 at 1 32 27 AM" src="https://github.com/user-attachments/assets/ebe3c0aa-2943-4b11-ba10-833c7ef86567" />



## NOW:


<img width="692" height="310" alt="Screenshot 2026-08-03 at 1 27 50 AM" src="https://github.com/user-attachments/assets/350183e9-a9a3-4033-9ca8-87a91860018d" />

<img width="709" height="557" alt="Screenshot 2026-08-03 at 1 26 05 AM" src="https://github.com/user-attachments/assets/22e2d8fc-1526-47d4-ac89-b72220ab4a39" />

