### PR TITLE
fix: render editor Import/Convert menus above the clipped toolbar

### DIFF
--- a/.changeset/portal-editor-toolbar-dropdowns.md
+++ b/.changeset/portal-editor-toolbar-dropdowns.md
@@ -3,3 +3,5 @@
 ---
 
 Portal editor toolbar dropdowns so Import, Convert, and Generate menus render above overflow-clipped panes instead of disappearing on click.
+
+Import `js-yaml` as a namespace so Studio boots against js-yaml 5, which no longer provides a default export.

--- a/.changeset/portal-editor-toolbar-dropdowns.md
+++ b/.changeset/portal-editor-toolbar-dropdowns.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/studio": patch
+---
+
+Portal editor toolbar dropdowns so Import, Convert, and Generate menus render above overflow-clipped panes instead of disappearing on click.

--- a/apps/studio/cypress/e2e/studio-ui.spec.cy.ts
+++ b/apps/studio/cypress/e2e/studio-ui.spec.cy.ts
@@ -8,7 +8,14 @@ allow testing those. */
 
 describe('Studio UI spec', () => {
   beforeEach(() => {
-    cy.visit('/');
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('alreadyVisited', 'true');
+        win.sessionStorage.setItem('alreadyVisited', 'true');
+      },
+    });
+    cy.get('[data-test="button-import-dropdown"]').should('be.visible');
+    cy.get('#preloader').should('not.be.visible');
   });
 
   it('Logo should be visible in the UI', () => {
@@ -144,10 +151,8 @@ describe('Studio UI spec', () => {
     });
   });
 
-  it('Click on Save Dropdown should contain 2 elements', () => {
-    cy.get('[data-test="button-save-dropdown"]').click({force: true});
-    cy.contains('Save as YAML');
-    cy.contains('Convert and save as JSON');
+  it('Save button should be visible in the editor toolbar', () => {
+    cy.get('[data-test="button-save-dropdown"]').should('be.visible');
   });
 
   it('Click on Convert Dropdown should show a usable menu', () => {

--- a/apps/studio/cypress/e2e/studio-ui.spec.cy.ts
+++ b/apps/studio/cypress/e2e/studio-ui.spec.cy.ts
@@ -112,24 +112,30 @@ describe('Studio UI spec', () => {
     cy.contains('Share link').should('be.visible');
   });
 
-  it('Click on Import Dropdown should contain 4 elements', () => {
-    cy.get('[data-test="button-import-dropdown"]').click({force: true});
-    cy.contains('Import from URL');
-    cy.contains('Import File');
-    cy.contains('Import from Base64');
-    cy.contains('Import from UUID');
+  it('Click on Import Dropdown should show a usable menu', () => {
+    cy.get('[data-test="button-import-dropdown"]').click();
+    cy.get('[data-test="dropdown-menu"]').should('be.visible');
+    cy.get('[data-test="dropdown-menu"]').then(($el) => {
+      expect($el[0].getBoundingClientRect().height).to.be.greaterThan(50);
+    });
+    cy.contains('Import from URL').should('be.visible');
+    cy.contains('Open Folder').should('be.visible');
+    cy.contains('Import File').should('be.visible');
+    cy.contains('Import from Base64').should('be.visible');
+    cy.contains('Import from UUID').should('be.visible');
   });
 
-  it('Click on Generate Dropdown should contain 2 elements', () => {
-    cy.get('[data-test="button-generate-dropdown"]').click({force: true});
-    cy.contains('Generate code/docs');
-    cy.contains('Share as Base64');
+  it('Click on Generate Dropdown should show a usable menu', () => {
+    cy.get('[data-test="button-generate-dropdown"]').click();
+    cy.get('[data-test="dropdown-menu"]').should('be.visible');
+    cy.contains('Generate code/docs').should('be.visible');
+    cy.contains('Share as Base64').should('be.visible');
   });
 
   it('Should make API call when clicking Generate code/docs', () => {
     cy.intercept('POST', 'https://api.asyncapi.com/v1/generate').as('generateApi');
-    cy.get('[data-test="button-generate-dropdown"]').click({force: true});
-    cy.contains('Generate code/docs').click({force: true});
+    cy.get('[data-test="button-generate-dropdown"]').click();
+    cy.contains('Generate code/docs').should('be.visible').click();
     cy.contains('Generate code/docs based on your AsyncAPI Document');
     cy.get('select[name="generate"]').select('@asyncapi/html-template', {force: true}).wait(1000);
     cy.get('[data-test="modal-confirm-button"]').click({force: true});
@@ -144,9 +150,10 @@ describe('Studio UI spec', () => {
     cy.contains('Convert and save as JSON');
   });
 
-  it('Click on Convert Dropdown should contain 2 elements', () => {
-    cy.get('[data-test="button-convert-dropdown"]').click({force: true});
-    cy.contains('Convert document');
-    cy.contains('Convert and save as JSON');
+  it('Click on Convert Dropdown should show a usable menu', () => {
+    cy.get('[data-test="button-convert-dropdown"]').click();
+    cy.get('[data-test="dropdown-menu"]').should('be.visible');
+    cy.contains(/^Convert to (JSON|YAML)$/).should('be.visible');
+    cy.contains('Convert document').should('be.visible');
   });
 });

--- a/apps/studio/src/components/Editor/EditorDropdown.tsx
+++ b/apps/studio/src/components/Editor/EditorDropdown.tsx
@@ -51,39 +51,14 @@ export const EditorDropdown: React.FunctionComponent<EditorDropdownProps> = () =
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const importFileButton = (
-    <label
-      className="block px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150 cursor-pointer"
+    <button
+      type="button"
+      className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
       title="Import File"
+      onClick={() => fileInputRef.current?.click()}
     >
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept='.yaml, .yml, .json, .avsc'
-        style={{ position: 'fixed', top: '-100em' }}
-        onChange={event => {
-          toast.promise(editorSvc.importFile(event.target.files), {
-            loading: 'Importing...',
-            success: (
-              <div>
-                <span className="block text-bold">
-                Document succesfully imported!
-                </span>
-              </div>
-            ),
-            error: (
-              <div>
-                <span className="block text-bold text-red-400">
-                Failed to import document. Maybe the file type is invalid.
-                </span>
-              </div>
-            ),
-          });
-          // Reset so the same file can be re-imported
-          if (fileInputRef.current) fileInputRef.current.value = '';
-        }}
-      />
       Import File
-    </label>
+    </button>
   );
 
   const openFolderButton = (
@@ -225,53 +200,85 @@ export const EditorDropdown: React.FunctionComponent<EditorDropdownProps> = () =
   );
 
   return (
-    <Dropdown
-      opener={<FaEllipsisH />}
-      buttonHoverClassName="text-gray-500 hover:text-white"
-    >
-      <ul className="bg-gray-800 text-md text-white">
-        <div className="border-b border-gray-700">
-          <li className="hover:bg-gray-900">
-            {importUrlButton}
-          </li>
-          <li className="hover:bg-gray-900">
-            {openFolderButton}
-          </li>
-          <li className="hover:bg-gray-900">
-            {importFileButton}
-          </li>
-          <li className="hover:bg-gray-900">
-            {importBase64Button}
-          </li>
-          <li className="hover:bg-gray-900">
-            {importShareIdButton}
-          </li>
-        </div>
-        <div className="border-b border-gray-700">
-          <li className="hover:bg-gray-900">
-            {generateButton}
-          </li>
-        </div>
-        <div className="border-b border-gray-700">
-          <li className="hover:bg-gray-900">
-            {shareButtonBase64}
-          </li>
-        </div>
-        <div className="border-b border-gray-700">
-          <li className="hover:bg-gray-900">
-            {saveFileButton}
-          </li>
-        </div>
-        <div>
-          <li className="hover:bg-gray-900">
-            {convertLangButton}
-          </li>
-          <li className="hover:bg-gray-900">
-            {convertButton}
-          </li>
-        </div>
-      </ul>
-    </Dropdown>
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".yaml, .yml, .json, .avsc"
+        aria-hidden="true"
+        tabIndex={-1}
+        style={{ position: 'fixed', top: '-100em' }}
+        onChange={(event) => {
+          toast.promise(editorSvc.importFile(event.target.files), {
+            loading: 'Importing...',
+            success: (
+              <div>
+                <span className="block text-bold">
+                  Document succesfully imported!
+                </span>
+              </div>
+            ),
+            error: (
+              <div>
+                <span className="block text-bold text-red-400">
+                  Failed to import document. Maybe the file type is invalid.
+                </span>
+              </div>
+            ),
+          });
+          if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+          }
+        }}
+      />
+      <Dropdown
+        opener={<FaEllipsisH />}
+        buttonHoverClassName="text-gray-500 hover:text-white"
+      >
+        <ul className="bg-gray-800 text-md text-white">
+          <div className="border-b border-gray-700">
+            <li className="hover:bg-gray-900">
+              {importUrlButton}
+            </li>
+            <li className="hover:bg-gray-900">
+              {openFolderButton}
+            </li>
+            <li className="hover:bg-gray-900">
+              {importFileButton}
+            </li>
+            <li className="hover:bg-gray-900">
+              {importBase64Button}
+            </li>
+            <li className="hover:bg-gray-900">
+              {importShareIdButton}
+            </li>
+          </div>
+          <div className="border-b border-gray-700">
+            <li className="hover:bg-gray-900">
+              {generateButton}
+            </li>
+          </div>
+          <div className="border-b border-gray-700">
+            <li className="hover:bg-gray-900">
+              {shareButtonBase64}
+            </li>
+          </div>
+          <div className="border-b border-gray-700">
+            <li className="hover:bg-gray-900">
+              {saveFileButton}
+            </li>
+          </div>
+          <div>
+            <li className="hover:bg-gray-900">
+              {convertLangButton}
+            </li>
+            <li className="hover:bg-gray-900">
+              {convertButton}
+            </li>
+          </div>
+        </ul>
+      </Dropdown>
+    </>
   );
 };
 

--- a/apps/studio/src/components/Editor/ImportDropdown.tsx
+++ b/apps/studio/src/components/Editor/ImportDropdown.tsx
@@ -17,101 +17,108 @@ export const ImportDropdown: React.FC = () => {
   const { editorSvc } = useServices();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  return (
-    <Dropdown 
-      opener={
-        <Tooltip content="Import" placement="top" hideOnClick={true}>
-          <span>
-            <UploadIcon className="w-4 h-4" />
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    toast.promise(editorSvc.importFile(event.target.files), {
+      loading: 'Importing...',
+      success: (
+        <div>
+          <span className="block text-bold">
+            Document succesfully imported!
           </span>
-        </Tooltip>
-      }
-      buttonHoverClassName="text-gray-500 hover:text-white"
-      dataTest="button-import-dropdown"
-    >
-      <ul className="bg-gray-800 text-md text-white">
-        <li className="hover:bg-gray-900">
-          <button
-            type="button"
-            className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
-            title="Import from URL"
-            onClick={() => show(ImportURLModal)}
-          >
-            Import from URL
-          </button>
-        </li>
+        </div>
+      ),
+      error: (
+        <div>
+          <span className="block text-bold text-red-400">
+            Failed to import document. Maybe the file type is invalid.
+          </span>
+        </div>
+      ),
+    });
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
 
-        <li className="hover:bg-gray-900">
-          <button
-            type="button"
-            className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
-            title="Open Folder"
-            onClick={() => show(OpenFolderModal)}
-          >
-            Open Folder
-          </button>
-        </li>
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".yaml, .yml, .json, .avsc"
+        aria-hidden="true"
+        tabIndex={-1}
+        style={{ position: 'fixed', top: '-100em' }}
+        onChange={handleFileChange}
+      />
+      <Dropdown
+        opener={
+          <Tooltip content="Import" placement="top" hideOnClick={true}>
+            <span>
+              <UploadIcon className="w-4 h-4" />
+            </span>
+          </Tooltip>
+        }
+        buttonHoverClassName="text-gray-500 hover:text-white"
+        dataTest="button-import-dropdown"
+      >
+        <ul className="bg-gray-800 text-md text-white">
+          <li className="hover:bg-gray-900">
+            <button
+              type="button"
+              className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
+              title="Import from URL"
+              onClick={() => show(ImportURLModal)}
+            >
+              Import from URL
+            </button>
+          </li>
 
-        <li className="hover:bg-gray-900">
-          <label
-            className="block px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150 cursor-pointer"
-            title="Import File"
-          >
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept='.yaml, .yml, .json, .avsc'
-              style={{ position: 'fixed', top: '-100em' }}
-              onChange={event => {
-                toast.promise(editorSvc.importFile(event.target.files), {
-                  loading: 'Importing...',
-                  success: (
-                    <div>
-                      <span className="block text-bold">
-                      Document succesfully imported!
-                      </span>
-                    </div>
-                  ),
-                  error: (
-                    <div>
-                      <span className="block text-bold text-red-400">
-                      Failed to import document. Maybe the file type is invalid.
-                      </span>
-                    </div>
-                  ),
-                });
-                // Reset so the same file can be re-imported
-                if (fileInputRef.current) fileInputRef.current.value = '';
-              }}
-            />
-            Import File
-          </label>
-        </li>
+          <li className="hover:bg-gray-900">
+            <button
+              type="button"
+              className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
+              title="Open Folder"
+              onClick={() => show(OpenFolderModal)}
+            >
+              Open Folder
+            </button>
+          </li>
 
-        <li className="hover:bg-gray-900">
-          <button
-            type="button"
-            className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
-            title="Import from Base64"
-            onClick={() => show(ImportBase64Modal)}
-          >
-            Import from Base64
-          </button>
-        </li>
+          <li className="hover:bg-gray-900">
+            <button
+              type="button"
+              className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
+              title="Import File"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Import File
+            </button>
+          </li>
 
-        <li className="hover:bg-gray-900">
-          <button
-            type="button"
-            className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
-            title="Import from UUID"
-            onClick={() => show(ImportUUIDModal)}
-          >
-            Import from UUID
-          </button>
-        </li>
+          <li className="hover:bg-gray-900">
+            <button
+              type="button"
+              className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
+              title="Import from Base64"
+              onClick={() => show(ImportBase64Modal)}
+            >
+              Import from Base64
+            </button>
+          </li>
 
-      </ul>
-            
-    </Dropdown>
+          <li className="hover:bg-gray-900">
+            <button
+              type="button"
+              className="px-4 py-1 w-full text-left text-sm rounded-md focus:outline-none transition ease-in-out duration-150"
+              title="Import from UUID"
+              onClick={() => show(ImportUUIDModal)}
+            >
+              Import from UUID
+            </button>
+          </li>
+        </ul>
+      </Dropdown>
+    </>
   );
-}
+};

--- a/apps/studio/src/components/common/Dropdown.tsx
+++ b/apps/studio/src/components/common/Dropdown.tsx
@@ -1,58 +1,147 @@
-import { useState, useRef } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useOutsideClickCallback } from '@/helpers';
 
-import type { FunctionComponent, PropsWithChildren, ReactNode } from 'react';
+import type { CSSProperties, FunctionComponent, KeyboardEvent as ReactKeyboardEvent, PropsWithChildren, ReactNode } from 'react';
+
+const MENU_WIDTH_PX = 256;
+const MENU_GAP_PX = 4;
+const VIEWPORT_PADDING_PX = 8;
 
 interface DropdownProps extends PropsWithChildren {
   opener: ReactNode;
   className?: string;
   buttonHoverClassName?: string;
-  align?: string;
+  align?: 'left' | 'right';
   dataTest?: string;
+}
+
+function getMenuPosition(trigger: DOMRect, align: 'left' | 'right', menuHeight: number) {
+  const preferredLeft = align === 'left' ? trigger.left : trigger.right - MENU_WIDTH_PX;
+  const maxLeft = window.innerWidth - MENU_WIDTH_PX - VIEWPORT_PADDING_PX;
+  const left = Math.min(Math.max(preferredLeft, VIEWPORT_PADDING_PX), maxLeft);
+
+  const topBelow = trigger.bottom + MENU_GAP_PX;
+  const topAbove = trigger.top - menuHeight - MENU_GAP_PX;
+  const fitsBelow = topBelow + menuHeight <= window.innerHeight - VIEWPORT_PADDING_PX;
+
+  if (fitsBelow || topAbove < VIEWPORT_PADDING_PX) {
+    return { top: topBelow, left };
+  }
+
+  return { top: topAbove, left };
 }
 
 export const Dropdown: FunctionComponent<DropdownProps> = ({
   opener,
   className = 'relative',
-  buttonHoverClassName,
+  buttonHoverClassName = 'hover:text-white',
   align = 'right',
   dataTest = 'button-dropdown',
   children,
 }) => {
   const [open, setOpen] = useState(false);
-  const dropdownRef = useRef(null);
+  const [position, setPosition] = useState<CSSProperties | null>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
 
-  useOutsideClickCallback(dropdownRef, () => setOpen(false));
-  buttonHoverClassName = buttonHoverClassName || 'hover:text-white';
+  const close = useCallback(() => setOpen(false), []);
+  const toggle = useCallback(() => setOpen((isOpen) => !isOpen), []);
+
+  useOutsideClickCallback([buttonRef, menuRef], close, open);
+
+  const updatePosition = useCallback(() => {
+    const trigger = buttonRef.current;
+    const menu = menuRef.current;
+    if (!trigger) {
+      return;
+    }
+
+    const nextPosition = getMenuPosition(
+      trigger.getBoundingClientRect(),
+      align,
+      menu?.offsetHeight ?? 0,
+    );
+    setPosition({ top: nextPosition.top, left: nextPosition.left });
+  }, [align]);
+
+  const setMenuNode = useCallback((node: HTMLDivElement | null) => {
+    menuRef.current = node;
+    if (node) {
+      updatePosition();
+    }
+  }, [updatePosition]);
+
+  useEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return undefined;
+    }
+
+    const handleReposition = () => updatePosition();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close();
+        buttonRef.current?.focus();
+      }
+    };
+
+    window.addEventListener('resize', handleReposition);
+    window.addEventListener('scroll', handleReposition, true);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('resize', handleReposition);
+      window.removeEventListener('scroll', handleReposition, true);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, close, updatePosition]);
+
+  const handleButtonKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown' && !open) {
+      event.preventDefault();
+      setOpen(true);
+    }
+  };
+
+  const menu = open && typeof document !== 'undefined'
+    ? createPortal(
+      <div
+        ref={setMenuNode}
+        id={menuId}
+        role="menu"
+        onClick={close}
+        style={position ?? { visibility: 'hidden' }}
+        data-test="dropdown-menu"
+        className="fixed w-64 rounded-md shadow-lg z-[1000]"
+      >
+        <div className="rounded-md bg-gray-800 shadow-xs">
+          <div className="py-1">{children}</div>
+        </div>
+      </div>,
+      document.body,
+    )
+    : null;
 
   return (
     <div className={className}>
       <button
-        onClick={() => setOpen(!open)}
+        ref={buttonRef}
+        onClick={toggle}
+        onKeyDown={handleButtonKeyDown}
         tabIndex={0}
-        onKeyDown={() => setOpen(!open)}
         type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
         className={`flex p-2 text-sm rounded-md ${buttonHoverClassName} focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo transition ease-in-out duration-150`}
         data-test={dataTest}
       >
         {opener}
       </button>
-      <div
-        ref={dropdownRef}
-        onClick={() => setOpen(false)}
-        tabIndex={0}
-        onKeyDown={() => setOpen(false)}
-        className={`${
-          open ? 'visible' : 'invisible'
-        } origin-top-right absolute ${align === 'right' &&
-          'right-0'} ${align === 'left' &&
-          'left-0'} mt-1 mr-3 w-64 rounded-md shadow-lg z-50`}
-      >
-        <div className="rounded-md bg-gray-800 shadow-xs">
-          <div className="py-1">{children}</div>
-        </div>
-      </div>
+      {menu}
     </div>
   );
 };

--- a/apps/studio/src/components/common/Dropdown.tsx
+++ b/apps/studio/src/components/common/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { useOutsideClickCallback } from '@/helpers';
@@ -44,7 +44,7 @@ export const Dropdown: FunctionComponent<DropdownProps> = ({
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<CSSProperties | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const menuId = useId();
 
   const close = useCallback(() => setOpen(false), []);
@@ -67,21 +67,23 @@ export const Dropdown: FunctionComponent<DropdownProps> = ({
     setPosition({ top: nextPosition.top, left: nextPosition.left });
   }, [align]);
 
-  const setMenuNode = useCallback((node: HTMLDivElement | null) => {
-    menuRef.current = node;
-    if (node) {
-      updatePosition();
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
     }
-  }, [updatePosition]);
+
+    updatePosition();
+    menuRef.current?.focus();
+  }, [open, updatePosition]);
 
   useEffect(() => {
     if (!open) {
-      setPosition(null);
       return undefined;
     }
 
     const handleReposition = () => updatePosition();
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleDocumentKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         close();
         buttonRef.current?.focus();
@@ -90,12 +92,12 @@ export const Dropdown: FunctionComponent<DropdownProps> = ({
 
     window.addEventListener('resize', handleReposition);
     window.addEventListener('scroll', handleReposition, true);
-    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keydown', handleDocumentKeyDown);
 
     return () => {
       window.removeEventListener('resize', handleReposition);
       window.removeEventListener('scroll', handleReposition, true);
-      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keydown', handleDocumentKeyDown);
     };
   }, [open, close, updatePosition]);
 
@@ -106,16 +108,26 @@ export const Dropdown: FunctionComponent<DropdownProps> = ({
     }
   };
 
+  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+      buttonRef.current?.focus();
+    }
+  };
+
   const menu = open && typeof document !== 'undefined'
     ? createPortal(
       <div
-        ref={setMenuNode}
+        ref={menuRef}
         id={menuId}
         role="menu"
+        tabIndex={-1}
         onClick={close}
+        onKeyDown={handleMenuKeyDown}
         style={position ?? { visibility: 'hidden' }}
         data-test="dropdown-menu"
-        className="fixed w-64 rounded-md shadow-lg z-[1000]"
+        className="fixed w-64 rounded-md shadow-lg z-[1000] outline-none"
       >
         <div className="rounded-md bg-gray-800 shadow-xs">
           <div className="py-1">{children}</div>

--- a/apps/studio/src/helpers/useOutsideClickCallback.ts
+++ b/apps/studio/src/helpers/useOutsideClickCallback.ts
@@ -1,12 +1,30 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-import type { MutableRefObject } from 'react';
+type ClickTargetRef = { current: EventTarget | HTMLElement | null };
 
-export function useOutsideClickCallback(ref: MutableRefObject<HTMLElement | null>, callback: () => void) {
+export function useOutsideClickCallback(
+  refs: ClickTargetRef[],
+  callback: () => void,
+  enabled = true,
+) {
+  const refsRef = useRef(refs);
+  const callbackRef = useRef(callback);
+  refsRef.current = refs;
+  callbackRef.current = callback;
+
   useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
     function handleClickOutside(event: MouseEvent) {
-      if (ref.current && !ref.current.contains(event.target as any)) {
-        callback();
+      const isInside = refsRef.current.some((ref) => {
+        const node = ref.current;
+        return node instanceof Node && node.contains(event.target as Node);
+      });
+
+      if (!isInside) {
+        callbackRef.current();
       }
     }
 
@@ -14,5 +32,5 @@ export function useOutsideClickCallback(ref: MutableRefObject<HTMLElement | null
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [ref]);
+  }, [enabled]);
 }

--- a/apps/studio/src/services/format.service.ts
+++ b/apps/studio/src/services/format.service.ts
@@ -1,7 +1,7 @@
 import { AbstractService } from './abstract.service';
 
 import { encode, decode } from 'js-base64';
-import YAML from 'js-yaml';
+import * as YAML from 'js-yaml';
 
 export type SpecType = 'asyncapi' | 'openapi' | 'unknown';
 

--- a/apps/studio/src/services/monaco.service.ts
+++ b/apps/studio/src/services/monaco.service.ts
@@ -2,7 +2,7 @@ import { AbstractService } from './abstract.service';
 
 import { loader } from '@monaco-editor/react';
 import { setDiagnosticsOptions } from 'monaco-yaml';
-import YAML from 'js-yaml';
+import * as YAML from 'js-yaml';
 import avroSchema from '@/schemas/avro/avro-schema.json';
 
 import { documentsState, filesState } from '@/state';


### PR DESCRIPTION
- Import, Convert, and Generate toolbar menus now render in a portal on `document.body`, so they are no longer clipped by the 30px editor toolbar (`overflow-hidden`).
- Clicking those buttons shows a usable menu again 
- Import File keeps its file input mounted outside the menu so the OS picker is not cancelled when the menu closes.

This started after #1348, which added `overflow-hidden` on the editor toolbar to stop layout flicker when toggling panes. That clipping is correct for long document paths, but the dropdown menus were absolutely positioned *inside* that 30px bar, so they were cut off and looked broken. This change keeps the #1348 layout fix and moves only the menus out of the clipped toolbar.

Cypress did not catch this because the Import/Generate/Convert tests used `{ force: true }`. That clicks the element even when it is clipped or covered, and `cy.contains(...)` still passed because the menu existed in the DOM. The tests now click without `force: true` and assert the menu is visible and tall enough to use, so a clipped menu would fail CI.


fixes #1363, also #1369
