### PR TITLE
test(services): add unit tests for settings.service

### DIFF
--- a/apps/studio/src/services/tests/settings.service.test.ts
+++ b/apps/studio/src/services/tests/settings.service.test.ts
@@ -1,0 +1,119 @@
+import { createServices } from '../';
+
+import type { SettingsService } from '../settings.service';
+import type { SettingsState } from '@/state/settings.state';
+
+describe('SettingsService', () => {
+  let settingsSvc: SettingsService;
+
+  const defaultState: SettingsState = {
+    governance: {
+      show: {
+        warnings: true,
+        informations: true,
+        hints: true,
+      },
+    },
+    templates: {
+      autoRendering: true,
+    },
+  };
+
+  beforeAll(async () => {
+    const services = await createServices();
+    settingsSvc = services.settingsSvc;
+  });
+
+  afterEach(() => {
+    // Reset to default settings state after each test
+    settingsSvc.set(defaultState);
+  });
+
+  describe('.get', () => {
+    test('should return current settings state', () => {
+      const state = settingsSvc.get();
+      expect(state).toEqual(defaultState);
+    });
+
+    test('should have expected governance properties', () => {
+      const state = settingsSvc.get();
+      expect(state.governance).toBeDefined();
+      expect(state.governance.show.warnings).toBe(true);
+      expect(state.governance.show.informations).toBe(true);
+      expect(state.governance.show.hints).toBe(true);
+    });
+
+    test('should have expected templates properties', () => {
+      const state = settingsSvc.get();
+      expect(state.templates).toBeDefined();
+      expect(state.templates.autoRendering).toBe(true);
+    });
+  });
+
+  describe('.set', () => {
+    test('should partially update templates state', () => {
+      settingsSvc.set({
+        templates: {
+          autoRendering: false,
+        },
+      });
+
+      const updated = settingsSvc.get();
+      expect(updated.templates.autoRendering).toBe(false);
+      expect(updated.governance.show.warnings).toBe(true);
+    });
+
+    test('should partially update governance state', () => {
+      settingsSvc.set({
+        governance: {
+          show: {
+            warnings: false,
+            informations: false,
+            hints: false,
+          },
+        },
+      });
+
+      const updated = settingsSvc.get();
+      expect(updated.governance.show.warnings).toBe(false);
+      expect(updated.governance.show.informations).toBe(false);
+      expect(updated.governance.show.hints).toBe(false);
+      expect(updated.templates.autoRendering).toBe(true);
+    });
+  });
+
+  describe('.isEqual', () => {
+    test('should return true for identical state', () => {
+      const current = settingsSvc.get();
+      expect(settingsSvc.isEqual(current)).toBe(true);
+    });
+
+    test('should return false when compared with different state', () => {
+      const differentState: SettingsState = {
+        governance: {
+          show: {
+            warnings: false,
+            informations: true,
+            hints: true,
+          },
+        },
+        templates: {
+          autoRendering: true,
+        },
+      };
+
+      expect(settingsSvc.isEqual(differentState)).toBe(false);
+    });
+
+    test('should return false when templates autoRendering differs', () => {
+      const differentState: SettingsState = {
+        ...defaultState,
+        templates: {
+          autoRendering: false,
+        },
+      };
+
+      expect(settingsSvc.isEqual(differentState)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Adds unit test coverage for `SettingsService` in `apps/studio/src/services/tests/settings.service.test.ts`.
- Tests `.get()` to verify accurate retrieval of the default `SettingsState` (both `governance` flags and `templates` configuration).
- Tests `.set()` to ensure partial updates to `templates` and nested `governance` properties update the store correctly while leaving untouched properties intact.
- Tests `.isEqual()` to ensure accurate deep equality comparisons against identical and modified settings states.
- Implements `afterEach` teardown resetting the store back to `defaultState` between tests to guarantee test isolation.
- Verified workspace code quality via `turbo run lint` (passed with 0 errors, 0 warnings).

**Related issue(s)**

Relates to #1246 (Part of #1246 - adding unit test coverage for services)
