### PR TITLE
feat: add RabbitMQ (AMQP) protocol example template

### DIFF
--- a/apps/studio/src/examples/index.tsx
+++ b/apps/studio/src/examples/index.tsx
@@ -6,6 +6,7 @@ import websocket from './websocket-gemini.yml';
 import mqtt from './streetlights-mqtt.yml';
 import simple from './simple.yml';
 import ibmmq from './ibmmq.yml';
+import rabbitmq from './rabbitmq-amqp.yml';
 
 // tutorial example
 import invalid from './tutorials/invalid.yml';
@@ -56,6 +57,12 @@ export default [
     title: 'IBM MQ',
     description: () => <>A robust, reliable, and secure messaging solution. IBM MQ simplifies and accelerates the integration of different applications across multiple platforms and supports a wide range of APIs and languages.</>,
     template: ibmmq,
+    type: templateTypes.protocol
+  },
+  {
+    title: 'RabbitMQ (AMQP)',
+    description: () => <>A widely deployed open source message broker using the AMQP protocol. Supports message routing via exchanges, queues, and routing keys.</>,
+    template: rabbitmq,
     type: templateTypes.protocol
   },
   {

--- a/apps/studio/src/examples/rabbitmq-amqp.yml
+++ b/apps/studio/src/examples/rabbitmq-amqp.yml
@@ -1,0 +1,103 @@
+asyncapi: 3.0.0
+info:
+  title: RabbitMQ (AMQP) Example
+  version: 1.0.0
+  description: |-
+    An example AsyncAPI specification for a RabbitMQ message broker using the AMQP 0-9-1 protocol.
+    Demonstrates exchange, routing key, and queue bindings for publishing and receiving messages.
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+defaultContentType: application/json
+servers:
+  rabbitmq:
+    host: 'rabbitmq.example.com:5672'
+    protocol: amqp
+    description: Production RabbitMQ AMQP Broker
+    bindings:
+      amqp:
+        bindingVersion: 0.3.0
+channels:
+  userSignups:
+    address: 'user.signup'
+    description: Topic exchange routing key for new user registrations
+    messages:
+      UserSignedUp:
+        $ref: '#/components/messages/UserSignedUp'
+    bindings:
+      amqp:
+        is: routingKey
+        exchange:
+          name: 'user.events'
+          type: topic
+          durable: true
+          autoDelete: false
+        bindingVersion: 0.3.0
+  userNotificationsQueue:
+    address: 'user.notifications'
+    description: Queue dedicated to processing user notification events
+    messages:
+      UserSignedUp:
+        $ref: '#/components/messages/UserSignedUp'
+    bindings:
+      amqp:
+        is: queue
+        queue:
+          name: 'user.notifications.queue'
+          durable: true
+          exclusive: false
+          autoDelete: false
+        bindingVersion: 0.3.0
+operations:
+  publishUserSignedUp:
+    action: send
+    channel:
+      $ref: '#/channels/userSignups'
+    summary: Publish new user sign-up event to the topic exchange
+    messages:
+      - $ref: '#/channels/userSignups/messages/UserSignedUp'
+    bindings:
+      amqp:
+        mandatory: true
+        deliveryMode: 2
+        bindingVersion: 0.3.0
+  consumeUserNotifications:
+    action: receive
+    channel:
+      $ref: '#/channels/userNotificationsQueue'
+    summary: Consume notification messages from the notification queue
+    messages:
+      - $ref: '#/channels/userNotificationsQueue/messages/UserSignedUp'
+    bindings:
+      amqp:
+        ack: true
+        bindingVersion: 0.3.0
+components:
+  messages:
+    UserSignedUp:
+      name: UserSignedUp
+      title: User Signed Up Event
+      summary: Event emitted whenever a new user creates an account
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          userId:
+            type: string
+            format: uuid
+            description: Unique identifier for the user
+          email:
+            type: string
+            format: email
+            description: Email address of the user
+          displayName:
+            type: string
+            description: Full display name of the user
+          signedUpAt:
+            type: string
+            format: date-time
+            description: ISO 8601 timestamp of registration
+        required:
+          - userId
+          - email
+          - signedUpAt

--- a/apps/studio/src/services/tests/examples.test.ts
+++ b/apps/studio/src/services/tests/examples.test.ts
@@ -1,0 +1,33 @@
+import { Parser } from '@asyncapi/parser';
+import examples from '../../examples';
+
+describe('Studio Examples', () => {
+  const parser = new Parser();
+
+  test('should include RabbitMQ (AMQP) template', () => {
+    const rabbitmqExample = examples.find(e => e.title === 'RabbitMQ (AMQP)');
+    expect(rabbitmqExample).toBeDefined();
+    expect(rabbitmqExample?.type).toEqual('protocol-example');
+    expect(typeof rabbitmqExample?.template).toEqual('string');
+  });
+
+  test('should parse RabbitMQ (AMQP) template without error diagnostics', async () => {
+    const rabbitmqExample = examples.find(e => e.title === 'RabbitMQ (AMQP)');
+    expect(rabbitmqExample?.template).toBeDefined();
+    const { document, diagnostics } = await parser.parse(rabbitmqExample?.template ?? '');
+    expect(document).toBeDefined();
+    const errorDiagnostics = diagnostics.filter(d => d.severity === 0);
+    expect(errorDiagnostics).toHaveLength(0);
+    expect(document?.version()).toEqual('3.0.0');
+    expect(document?.info().title()).toEqual('RabbitMQ (AMQP) Example');
+  });
+
+  test('all examples should have title, description function, and template', () => {
+    for (const example of examples) {
+      expect(example.title).toBeDefined();
+      expect(typeof example.description).toEqual('function');
+      expect(typeof example.template).toEqual('string');
+      expect(example.template.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,6 +1,6 @@
 import sharedConfig from 'tailwind-config/tailwind.config.js';
 
-module.exports = {
+export default {
   content: ['./components/**/*.tsx'],
   presets: [sharedConfig],
   theme: {


### PR DESCRIPTION
### Description
This PR resolves #1253 by adding a new RabbitMQ (AMQP 0-9-1) protocol template example to AsyncAPI Studio (`rabbitmq-amqp.yml`), registered under the protocol examples in `apps/studio/src/examples/index.tsx`.

### Motivation & Context
- As requested in #1253, Studio previously lacked a dedicated RabbitMQ / AMQP protocol template for users building event-driven systems on AMQP brokers.
- The template uses standard AsyncAPI 3.0 specification syntax demonstrating:
  - AMQP server definition (`amqp` protocol with AMQP 0.3.0 binding).
  - Exchange routing key channel binding (`is: routingKey`, topic exchange `type: topic`).
  - Queue channel binding (`is: queue`, durable queue).
  - AMQP operation bindings (`deliveryMode`, `mandatory`, `ack`).
  - Structured schema payload with `UserSignedUp` components message definition.
- Adds unit tests in `apps/studio/src/services/tests/examples.test.ts` verifying template registration and error-free AST parsing by `@asyncapi/parser`.

### Changes Made
- Added `apps/studio/src/examples/rabbitmq-amqp.yml` with complete AsyncAPI 3.0 AMQP specification.
- Imported and registered RabbitMQ AMQP template in `apps/studio/src/examples/index.tsx`.
- Added unit test suite in `apps/studio/src/services/tests/examples.test.ts`.
- Fixed ESM export in `packages/ui/tailwind.config.js`.

### Checks
- [x] `pnpm run lint` passes with 0 errors / 0 warnings (`✔ No ESLint warnings or errors`).
- [x] `pnpm run build` passes cleanly across all workspace packages.
- [x] Added automated tests.

Fixes #1253
